### PR TITLE
Respond 404 status code when hander is not exist.

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,0 +1,17 @@
+import concurrent.Future
+import play.api.GlobalSettings
+import play.api.Mode
+import play.api.Play
+import play.api.mvc.RequestHeader
+import play.api.mvc.Results.NotFound
+import play.api.mvc.SimpleResult
+
+object Global extends GlobalSettings {
+  override def onHandlerNotFound(request: RequestHeader): Future[SimpleResult] = {
+    Play.maybeApplication.filter(_.mode == Mode.Prod).map { _ =>
+      Future.successful(NotFound)
+    } getOrElse {
+      super.onHandlerNotFound(request)
+    }
+  }
+}


### PR DESCRIPTION
Default onHandlerNotFound method returns error page. But beyond
framework just needs 404 Response, because beyond framework will use
REST api only.

This patch makes server respond 404 status code without body when it
runs with production mode.
