### PR TITLE
Use current.configuration instead of configuration in GlobalSettings.

### DIFF
--- a/app/beyond/Global.scala
+++ b/app/beyond/Global.scala
@@ -54,19 +54,26 @@ object Global extends WithFilters(TimeoutFilter) with Logging {
     }
   }
 
-  def requestTimeout: FiniteDuration =
-    Duration(configuration.getString("beyond.request-timeout").getOrElse("30s")).asInstanceOf[FiniteDuration]
+  def requestTimeout: FiniteDuration = {
+    import play.api.Play.current
+    Duration(current.configuration.getString("beyond.request-timeout").getOrElse("30s")).asInstanceOf[FiniteDuration]
+  }
 
-  def mongoDBPath: String =
-    configuration.getString("beyond.mongodb.dbpath").getOrElse("data")
+  def mongoDBPath: String = {
+    import play.api.Play.current
+    current.configuration.getString("beyond.mongodb.dbpath").getOrElse("data")
+  }
 
-  def zooKeeperConfigPath: String =
-    configuration.getString("beyond.zookeeper.config-path").getOrElse("conf/zoo.cfg")
+  def zooKeeperConfigPath: String = {
+    import play.api.Play.current
+    current.configuration.getString("beyond.zookeeper.config-path").getOrElse("conf/zoo.cfg")
+  }
 
   def pluginPaths: Seq[String] = {
+    import play.api.Play.current
     import scala.collection.JavaConverters._
     val defaultModulePaths = Seq("plugins")
-    configuration.getStringList("beyond.plugin.path").map(_.asScala).getOrElse(defaultModulePaths)
+    current.configuration.getStringList("beyond.plugin.path").map(_.asScala).getOrElse(defaultModulePaths)
   }
 }
 


### PR DESCRIPTION
The purpose of the configuration in GlobalSettings is to supply a hook
to modify configuration by overriding it on loading time.
Unless Global doesn't override it, it is just empty configuration.

Use play.api.Play.current.configuration, if you want to read current
configuration.
