### PR TITLE
Use empty array as default data of RoutingTable in zookeeper.

### DIFF
--- a/app/beyond/route/RoutingTableLeader.scala
+++ b/app/beyond/route/RoutingTableLeader.scala
@@ -30,8 +30,11 @@ class RoutingTableLeader extends LeaderSelectorListenerAdapter with Actor with A
       curatorFramework.start()
       curatorResources.push(curatorFramework)
 
-      Seq(WorkersPath, RoutingTablePath, LeaderPath)
-        .foreach(curatorFramework.create().inBackground().forPath)
+      def ensurePath(path: String, data: Array[Byte] = Array[Byte](0)) {
+        curatorFramework.create().inBackground().forPath(path, data)
+      }
+      Seq(WorkersPath, LeaderPath).foreach(ensurePath(_))
+      ensurePath(RoutingTablePath, "[]".getBytes("UTF-8"))
 
       val leaderSelector = new LeaderSelector(curatorFramework, LeaderPath, this)
       leaderSelector.autoRequeue()


### PR DESCRIPTION
Bug fix for #32.

Currently, JsonParseException is often occured.
This is because I parsed data in the RoutingTable node if exists.
I expected znode has null data, when znode is created without passed
data. But Curator passes client IP as data if no data is passed.

This patch passes empty JsArray as data when RoutingTalbe node is
created.
