### PR TITLE
Get rid of port from server address.

### DIFF
--- a/app/beyond/BeyondConfiguration.scala
+++ b/app/beyond/BeyondConfiguration.scala
@@ -33,10 +33,5 @@ object BeyondConfiguration {
     new ExponentialBackoffRetry(baseSleepTimeMs, maxRetries, maxSleepMs)
   }
 
-  def currentServerAddress: String = {
-    val hostAddress = configuration.getString("http.address").get
-    val port = configuration.getInt("http.port").get
-
-    hostAddress + ":" + port.toString
-  }
+  def currentServerAddress: String = configuration.getString("http.address").get
 }


### PR DESCRIPTION
Port number is fixed ("http.port"), so there is no need to pass it around.
