### PR TITLE
Revert "Check style errors before running tests on Travis."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,1 @@
 language: scala
-script: sbt scalastyle && sbt test


### PR DESCRIPTION
This reverts commit 4451de631d6471449508a6d9939ebe630540bd83.

We don't need a script to run scalastyle before test, because 43f7d53ca5
makes test depends on scalastyle.
