### PR TITLE
Extract PathChildrenCacheActor from RoutingTableLeader.

### DIFF
--- a/app/beyond/PathChildrenCacheActor.scala
+++ b/app/beyond/PathChildrenCacheActor.scala
@@ -1,0 +1,56 @@
+package beyond
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.recipes.cache.ChildData
+import org.apache.curator.framework.recipes.cache.PathChildrenCache
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener
+
+object PathChildrenCacheActor {
+  sealed trait PathChildrenCacheMessage
+  case class ChildAdded(childData: String) extends PathChildrenCacheMessage
+  case class ChildRemoved(childData: String) extends PathChildrenCacheMessage
+}
+
+class PathChildrenCacheActor(curatorFramework: CuratorFramework, path: String) extends PathChildrenCacheListener with Actor with ActorLogging {
+  import PathChildrenCacheActor._
+
+  val cache = new PathChildrenCache(curatorFramework, path, true)
+
+  override def preStart() {
+    try {
+      cache.start()
+      cache.getListenable.addListener(this)
+    } catch {
+      case ex: Throwable =>
+        cache.close()
+        throw ex
+    }
+    log.info(s"PathChildrenCacheActor started: path=$path")
+  }
+
+  override def postStop() {
+    cache.close()
+    log.info(s"PathChildrenCacheActor stopped: path=$path")
+  }
+
+  // childEvent is called by an internal Curator thread.
+  override def childEvent(framework: CuratorFramework, event: PathChildrenCacheEvent) {
+    event.getType match {
+      case PathChildrenCacheEvent.Type.CHILD_ADDED =>
+        val worker: ChildData = event.getData
+        context.parent ! ChildAdded(new String(worker.getData))
+      case PathChildrenCacheEvent.Type.CHILD_REMOVED =>
+        val worker: ChildData = event.getData
+        context.parent ! ChildRemoved(new String(worker.getData))
+      case _ => // Ignore other events.
+    }
+  }
+
+  override def receive: Receive = {
+    case _ =>
+  }
+}
+

--- a/app/beyond/route/RoutingTableLeader.scala
+++ b/app/beyond/route/RoutingTableLeader.scala
@@ -2,21 +2,21 @@ package beyond.route
 
 import akka.actor.Actor
 import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.Props
 import beyond.LeaderSelectorActor._
+import beyond.PathChildrenCacheActor
 import beyond.route.RoutingTableConfig._
-import java.io.Closeable
 import org.apache.curator.framework.CuratorFramework
-import org.apache.curator.framework.recipes.cache.ChildData
-import org.apache.curator.framework.recipes.cache.PathChildrenCache
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener
 import play.api.libs.json.Json
 
 object RoutingTableLeader {
   val Name: String = "routingTableLeader"
 }
 
-class RoutingTableLeader(curatorFramework: CuratorFramework) extends PathChildrenCacheListener with Actor with ActorLogging {
+class RoutingTableLeader(curatorFramework: CuratorFramework) extends Actor with ActorLogging {
+  import PathChildrenCacheActor._
+
   private val routingTableBuilder: RoutingTableBuilder = new RoutingTableBuilder
 
   override def preStart() {
@@ -29,42 +29,27 @@ class RoutingTableLeader(curatorFramework: CuratorFramework) extends PathChildre
     log.info("RoutingTableLeader stopped")
   }
 
-  override def childEvent(framework: CuratorFramework, event: PathChildrenCacheEvent) {
-    def saveRoutingTableToServer(routingTableBuilder: RoutingTableBuilder) {
-      val routingTableToSave: Array[Byte] = Json.stringify(Json.toJson(routingTableBuilder)).getBytes("UTF-8")
-      framework.setData().inBackground().forPath(RoutingTablePath, routingTableToSave)
-    }
-    event.getType match {
-      case PathChildrenCacheEvent.Type.CHILD_ADDED =>
-        val addedWorker: ChildData = event.getData
-        routingTableBuilder.add(new String(addedWorker.getData))
-        saveRoutingTableToServer(routingTableBuilder)
-      case PathChildrenCacheEvent.Type.CHILD_REMOVED =>
-        val removedWorker: ChildData = event.getData
-        routingTableBuilder.remove(new String(removedWorker.getData))
-        saveRoutingTableToServer(routingTableBuilder)
-      case _ => // Ignore other events.
-    }
+  private def saveRoutingTableToServer() {
+    val routingTableToSave: Array[Byte] = Json.stringify(Json.toJson(routingTableBuilder)).getBytes("UTF-8")
+    curatorFramework.setData().inBackground().forPath(RoutingTablePath, routingTableToSave)
   }
 
   private def receiveWithoutLeadership: Receive = {
     case LeadershipTaken =>
-      val cache = new PathChildrenCache(curatorFramework, WorkersPath, true)
-      try {
-        cache.start()
-        cache.getListenable.addListener(this)
-      } catch {
-        case ex: Throwable =>
-          cache.close()
-          throw ex
-      }
+      val cache = context.actorOf(Props(classOf[PathChildrenCacheActor], curatorFramework, WorkersPath))
       context.become(receiveWithLeadership(cache))
   }
 
-  private def receiveWithLeadership(cache: Closeable): Receive = {
+  private def receiveWithLeadership(cache: ActorRef): Receive = {
+    case ChildAdded(childData) =>
+      routingTableBuilder.add(childData)
+      saveRoutingTableToServer()
+    case ChildRemoved(childData) =>
+      routingTableBuilder.remove(childData)
+      saveRoutingTableToServer()
     case LeadershipLost =>
-      cache.close()
-      context.become(receive)
+      context.stop(cache)
+      context.become(receiveWithoutLeadership)
   }
 
   override def receive: Receive = {


### PR DESCRIPTION
This is a refactoring patch to reuse PathChildrenCacheActor.
