### PR TITLE
Rename routing table actors appropriately.

### DIFF
--- a/app/beyond/BeyondSupervisor.scala
+++ b/app/beyond/BeyondSupervisor.scala
@@ -4,7 +4,7 @@ import akka.actor.Actor
 import akka.actor.OneForOneStrategy
 import akka.actor.Props
 import akka.actor.SupervisorStrategy._
-import beyond.UserActionActor.UpdateRoutingTable
+import beyond.UserActionActor.NewRoutingTable
 import beyond.plugin.GamePlugin
 import beyond.launcher.LauncherSupervisor
 

--- a/app/beyond/CuratorSupervisor.scala
+++ b/app/beyond/CuratorSupervisor.scala
@@ -3,8 +3,8 @@ package beyond
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.Props
-import beyond.route.RoutingTableLeader
-import beyond.route.RoutingTableUpdateActor
+import beyond.route.RoutingTableUpdater
+import beyond.route.RoutingTableWatcher
 import com.typesafe.scalalogging.slf4j.{ StrictLogging => Logging }
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.CuratorFrameworkFactory
@@ -31,8 +31,8 @@ class CuratorSupervisor extends Actor with ActorLogging {
   context.actorOf(Props(classOf[LeaderSelectorActor], curatorFramework), LeaderSelectorActor.Name)
   context.actorOf(Props(classOf[WorkerRegistrationActor], curatorFramework), WorkerRegistrationActor.Name)
 
-  context.actorOf(Props(classOf[RoutingTableLeader], curatorFramework), RoutingTableLeader.Name)
-  context.actorOf(Props(classOf[RoutingTableUpdateActor], curatorFramework), RoutingTableUpdateActor.Name)
+  context.actorOf(Props(classOf[RoutingTableUpdater], curatorFramework), RoutingTableUpdater.Name)
+  context.actorOf(Props(classOf[RoutingTableWatcher], curatorFramework), RoutingTableWatcher.Name)
 
   override def postStop() {
     curatorFramework.close()

--- a/app/beyond/UserActionActor.scala
+++ b/app/beyond/UserActionActor.scala
@@ -27,7 +27,7 @@ object UserActionActor {
     override def consistentHashKey: Any = request.consistentHashKey
   }
 
-  case class UpdateRoutingTable(data: JsArray)
+  case class NewRoutingTable(data: JsArray)
 }
 
 private class UserActionActor extends Actor with ActorLogging {
@@ -53,7 +53,7 @@ private class UserActionActor extends Actor with ActorLogging {
           log.info("Request by {} is redirected to {}", request.username, address)
           sender ! new Status(RedirectStatusCode)(address)
       }
-    case UpdateRoutingTable(jsRoutingTable) =>
+    case NewRoutingTable(jsRoutingTable) =>
       log.info("Routing table is updated.")
       routingTable = new RoutingTableView(BeyondConfiguration.currentServerAddress, jsRoutingTable)
   }

--- a/app/beyond/UserActionSupervisor.scala
+++ b/app/beyond/UserActionSupervisor.scala
@@ -5,7 +5,7 @@ import akka.actor.Props
 import akka.actor.SupervisorStrategy
 import akka.routing.Broadcast
 import akka.routing.ConsistentHashingRouter
-import beyond.UserActionActor.UpdateRoutingTable
+import beyond.UserActionActor.NewRoutingTable
 import play.api.libs.json.JsArray
 
 object UserActionSupervisor {
@@ -40,10 +40,10 @@ class UserActionSupervisor extends Actor {
   }
 
   override def receive: Receive = {
-    case msg: UpdateRoutingTable =>
+    case msg: NewRoutingTable =>
       routingTableData = msg.data
       userActionActor.tell(Broadcast(msg), sender)
     case RequestRoutingTable =>
-      sender ! UpdateRoutingTable(routingTableData)
+      sender ! NewRoutingTable(routingTableData)
   }
 }

--- a/app/beyond/route/RoutingTableUpdater.scala
+++ b/app/beyond/route/RoutingTableUpdater.scala
@@ -10,11 +10,11 @@ import beyond.route.RoutingTableConfig._
 import org.apache.curator.framework.CuratorFramework
 import play.api.libs.json.Json
 
-object RoutingTableLeader {
-  val Name: String = "routingTableLeader"
+object RoutingTableUpdater {
+  val Name: String = "routingTableUpdater"
 }
 
-class RoutingTableLeader(curatorFramework: CuratorFramework) extends Actor with ActorLogging {
+class RoutingTableUpdater(curatorFramework: CuratorFramework) extends Actor with ActorLogging {
   import beyond.WorkerRegistrationActor._
   import PathChildrenCacheActor._
 

--- a/app/beyond/route/RoutingTableWatcher.scala
+++ b/app/beyond/route/RoutingTableWatcher.scala
@@ -3,18 +3,18 @@ package beyond.route
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import beyond.BeyondSupervisor.UserActionSupervisorPath
-import beyond.UserActionActor.UpdateRoutingTable
+import beyond.UserActionActor.NewRoutingTable
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.cache.NodeCache
 import org.apache.curator.framework.recipes.cache.NodeCacheListener
 import play.api.libs.json.JsArray
 import play.api.libs.json.Json
 
-object RoutingTableUpdateActor {
-  val Name: String = "routingTableUpdateActor"
+object RoutingTableWatcher {
+  val Name: String = "routingTableWatcher"
 }
 
-class RoutingTableUpdateActor(curatorFramework: CuratorFramework) extends NodeCacheListener with Actor with ActorLogging {
+class RoutingTableWatcher(curatorFramework: CuratorFramework) extends NodeCacheListener with Actor with ActorLogging {
   import beyond.route.RoutingTableConfig._
 
   private val userActionSupervisor = {
@@ -33,7 +33,7 @@ class RoutingTableUpdateActor(curatorFramework: CuratorFramework) extends NodeCa
 
   override def nodeChanged() {
     val changedData = routingTableWatcher.getCurrentData.getData
-    userActionSupervisor.tell(UpdateRoutingTable(Json.parse(changedData).as[JsArray]), sender)
+    userActionSupervisor.tell(NewRoutingTable(Json.parse(changedData).as[JsArray]), sender)
   }
 
   override def preStart() {


### PR DESCRIPTION
Currently, the names of routing table actors are confusing because we use
'update' with different meanings in different contexts. Use terms from the
perspective of ZooKeeper so that update menas znode update and watch means
znode watch.
