### PR TITLE
Make names more specific.

### DIFF
--- a/app/beyond/UserActionActor.scala
+++ b/app/beyond/UserActionActor.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorLogging
 import akka.pattern.pipe
 import akka.routing.ConsistentHashingRouter.ConsistentHashable
 import beyond.UserActionSupervisor.RequestRoutingTable
-import beyond.route.Address
+import beyond.route.RouteAddress
 import beyond.route.RoutingTableView
 import beyond.route.RoutingTableView._
 import play.api.libs.json.JsArray
@@ -48,7 +48,7 @@ private class UserActionActor extends Actor with ActorLogging {
           import play.api.Play.current
           implicit val ec: ExecutionContext = Akka.system.dispatcher
           block(request) pipeTo sender
-        case HandleIn(address: Address) =>
+        case HandleIn(address: RouteAddress) =>
           val RedirectStatusCode = 310 // This code is just one of a redirection code not used by HTTP. It can be changed.
           log.info("Request by {} is redirected to {}", request.username, address)
           sender ! new Status(RedirectStatusCode)(address)

--- a/app/beyond/route/RoutingTableBuilder.scala
+++ b/app/beyond/route/RoutingTableBuilder.scala
@@ -7,11 +7,11 @@ import play.api.libs.json.Writes
 import scala.collection.mutable
 
 object RoutingTableBuilder {
-  type RoutingTableInternal = mutable.HashMap[Hash, Address]
+  type RoutingTableInternal = mutable.HashMap[RouteHash, RouteAddress]
 
   implicit val routingTableBuilderWrites = new Writes[RoutingTableBuilder] {
     def writes(builder: RoutingTableBuilder): JsValue =
-      Json.toJson(builder.routingTable.map { case (hash, address) => Server(hash, address) })
+      Json.toJson(builder.routingTable.map { case (hash, address) => RouteHashAndAddress(hash, address) })
   }
 }
 
@@ -20,7 +20,7 @@ class RoutingTableBuilder {
   private val routingTable: RoutingTableInternal = new RoutingTableInternal
 
   // This hash result will be used in consistent hashing for load balancing.
-  private def hash(address: Address): Hash = {
+  private def hash(address: RouteAddress): RouteHash = {
     // FIXME: Make maximumHash configurable
     val maximumHash = 1000
     // FIXME: Use a better hashing algorithm.
@@ -31,11 +31,11 @@ class RoutingTableBuilder {
     Integer.parseInt(Codecs.md5(address.getBytes("UTF-8")).substring(startIndex, endIndex), digits) % maximumHash
   }
 
-  def add(address: Address) {
+  def add(address: RouteAddress) {
     routingTable += ((hash(address), address))
   }
 
-  def remove(address: Address) {
+  def remove(address: RouteAddress) {
     routingTable - hash(address)
   }
 }

--- a/app/beyond/route/RoutingTableView.scala
+++ b/app/beyond/route/RoutingTableView.scala
@@ -5,18 +5,18 @@ import play.api.libs.json.JsArray
 import play.api.libs.json.Json
 
 object RoutingTableView {
-  type RoutingTableInternal = Seq[Server]
+  type RoutingTableInternal = Seq[RouteHashAndAddress]
 
   sealed trait ServerToHandle
   case object HandleHere extends ServerToHandle
-  case class HandleIn(address: Address) extends ServerToHandle
+  case class HandleIn(address: RouteAddress) extends ServerToHandle
 }
 
-class RoutingTableView(currentServer: Address, data: JsArray = new JsArray) extends Logging {
+class RoutingTableView(currentServer: RouteAddress, data: JsArray = new JsArray) extends Logging {
   import RoutingTableView._
 
-  private val routingTable: RoutingTableInternal = Json.fromJson[RoutingTableInternal](data).get.sorted(new Ordering[Server] {
-    override def compare(lhs: Server, rhs: Server): Int = lhs.hash compare rhs.hash
+  private val routingTable: RoutingTableInternal = Json.fromJson[RoutingTableInternal](data).get.sorted(new Ordering[RouteHashAndAddress] {
+    override def compare(lhs: RouteHashAndAddress, rhs: RouteHashAndAddress): Int = lhs.hash compare rhs.hash
   })
 
   // Currently, time complexity of this method is O(n) when n = number of
@@ -24,12 +24,12 @@ class RoutingTableView(currentServer: Address, data: JsArray = new JsArray) exte
   // of server will not be large. But this method is called for every
   // RequestWithUsername, so it can be a bottleneck. If you can reduce
   // time complexity, please fix it.
-  def queryServerToHandle(hash: Hash): ServerToHandle = {
+  def queryServerToHandle(hash: RouteHash): ServerToHandle = {
     // When there are three servers, and hash of server1 is 100, server2 is 300 and server3 is 700,
     // server1 will handle requests whose hash is less than or equal to 100 and more than 700.
     // server2 will handle requests whose hash is in (100, 300].
     // server3 will handle requests whose hash is in (300, 700].
-    def whoWillHandle(hash: Hash): Address = {
+    def whoWillHandle(hash: RouteHash): RouteAddress = {
       // Basically, find the first server that the hash of server is less than
       // or equal to the hash of the request.
       //
@@ -43,7 +43,7 @@ class RoutingTableView(currentServer: Address, data: JsArray = new JsArray) exte
       //      requests in the current server. This is okay because each server
       //      doesn't have internal states, and consistent hashing is used just
       //      for load balancing.
-      val fallbackAddress: Address = routingTable.headOption.fold({
+      val fallbackAddress: RouteAddress = routingTable.headOption.fold({
         logger.warn("There is no data in the routing table.")
         currentServer
       })(_.address)
@@ -51,7 +51,7 @@ class RoutingTableView(currentServer: Address, data: JsArray = new JsArray) exte
     }
 
     whoWillHandle(hash) match {
-      case address: Address if address != currentServer => HandleIn(address)
+      case address: RouteAddress if address != currentServer => HandleIn(address)
       case _ => HandleHere
     }
   }

--- a/app/beyond/route/package.scala
+++ b/app/beyond/route/package.scala
@@ -4,21 +4,22 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 package object route {
-  type Address = String
-  type Hash = Int
+  // RouteAddress is like "127.0.0.1:8080"
+  type RouteAddress = String
+  type RouteHash = Int
 
-  implicit val serverWrites: Writes[Server] = (
-    (__ \ "hash").write[Hash] and
-    (__ \ "address").write[Address]
-  )(unlift(Server.unapply))
+  implicit val routeWrites: Writes[RouteHashAndAddress] = (
+    (__ \ "hash").write[RouteHash] and
+    (__ \ "address").write[RouteAddress]
+  )(unlift(RouteHashAndAddress.unapply))
 
-  implicit val serverReads: Reads[Server] = (
-    (__ \ "hash").read[Hash] and
-    (__ \ "address").read[Address]
-  )(Server)
+  implicit val routeReads: Reads[RouteHashAndAddress] = (
+    (__ \ "hash").read[RouteHash] and
+    (__ \ "address").read[RouteAddress]
+  )(RouteHashAndAddress)
 
-  implicit val locationFormat: Format[Server] =
-    Format(serverReads, serverWrites)
+  implicit val routeFormat: Format[RouteHashAndAddress] =
+    Format(routeReads, routeWrites)
 
-  case class Server(hash: Hash, address: Address)
+  case class RouteHashAndAddress(hash: RouteHash, address: RouteAddress)
 }


### PR DESCRIPTION
Names such as Address, Hash and Server are too generic. Rename them to
RouteAddress, RouteHash and RouteHashAndAddress respectively to reflect that
they are used only when calculating routing table.

Also add a comment which shows the format of RoutingAddress:
e.g., "127.0.0.1:8080"
