### PR TITLE
Add an extractor for RouteAddress.

### DIFF
--- a/app/beyond/BeyondConfiguration.scala
+++ b/app/beyond/BeyondConfiguration.scala
@@ -1,5 +1,6 @@
 package beyond
 
+import beyond.route.RouteAddress
 import org.apache.curator.RetryPolicy
 import org.apache.curator.retry.ExponentialBackoffRetry
 import scala.concurrent.duration.Duration
@@ -33,10 +34,10 @@ object BeyondConfiguration {
     new ExponentialBackoffRetry(baseSleepTimeMs, maxRetries, maxSleepMs)
   }
 
-  def currentServerAddress: String = {
+  def currentServerAddress: RouteAddress = {
     val hostAddress = configuration.getString("http.address").get
     val port = configuration.getInt("http.port").get
 
-    hostAddress + ":" + port.toString
+    RouteAddress(hostAddress, port.toString)
   }
 }

--- a/app/beyond/route/package.scala
+++ b/app/beyond/route/package.scala
@@ -8,6 +8,15 @@ package object route {
   type RouteAddress = String
   type RouteHash = Int
 
+  object RouteAddress {
+    def apply(ip: String, port: String): RouteAddress = ip + ":" + port
+
+    def unapply(str: RouteAddress): Option[(String, String)] = {
+      val parts = str split ":"
+      if (parts.length == 2) Some(parts(0), parts(1)) else None
+    }
+  }
+
   implicit val routeWrites: Writes[RouteHashAndAddress] = (
     (__ \ "hash").write[RouteHash] and
     (__ \ "address").write[RouteAddress]


### PR DESCRIPTION
This patch introduces an extractor for RouteAddress which is handy for parsing
RouteAddress into IP and port. The extractor will be used later in management
console to gather list of workers.

Change the return type of BeyondConfiguration.currentServerAddress to
RouteAddress to make it explicit that it returns an instance of RouteAddress
that can be parsed with the extractor.
