### PR TITLE
Don't hardcode the name of BeyondSupervisor.

### DIFF
--- a/app/beyond/BeyondSupervisor.scala
+++ b/app/beyond/BeyondSupervisor.scala
@@ -12,8 +12,10 @@ import beyond.plugin.GamePlugin
 import beyond.launcher.LauncherSupervisor
 
 object BeyondSupervisor {
+  val Name: String = "beyondSupervisor"
+
   val RootActorPath: ActorPath = new RootActorPath(Address("akka", "application"))
-  val BeyondSupervisorPath: ActorPath = RootActorPath / "user" / "beyondSupervisor"
+  val BeyondSupervisorPath: ActorPath = RootActorPath / "user" / BeyondSupervisor.Name
   val UserActionSupervisorPath: ActorPath = BeyondSupervisorPath / UserActionSupervisor.Name
   val UserActionActorPath: ActorPath = UserActionSupervisorPath / UserActionActor.Name
 }

--- a/app/beyond/Global.scala
+++ b/app/beyond/Global.scala
@@ -55,7 +55,7 @@ object Global extends WithFilters(TimeoutFilter) with Logging {
 
   override def onStart(app: Application) {
     logger.info("Beyond started")
-    beyondSupervisor = Some(Akka.system(app).actorOf(Props[BeyondSupervisor], name = "beyondSupervisor"))
+    beyondSupervisor = Some(Akka.system(app).actorOf(Props[BeyondSupervisor], name = BeyondSupervisor.Name))
   }
 
   override def onStop(app: Application) {


### PR DESCRIPTION
Add BeyondSupervisor.Name field to be consistent with other actors.
