### PR TITLE
Check sigar is registered before register.

### DIFF
--- a/app/beyond/metrics/SystemMetricsMonitor.scala
+++ b/app/beyond/metrics/SystemMetricsMonitor.scala
@@ -43,7 +43,11 @@ class SystemMetricsMonitor extends Actor with ActorLogging {
 
   override def preStart() {
     val server: MBeanServer = ManagementFactory.getPlatformMBeanServer
-    server.registerMBean(new SigarRegistry, null)
+    val sigar = new SigarRegistry
+    val sigarName = new ObjectName(sigar.getObjectName)
+    if (!server.isRegistered(sigarName)) {
+      server.registerMBean(sigar, sigarName)
+    }
 
     try {
       val vm = VirtualMachine.attach(BeyondRuntime.processID)


### PR DESCRIPTION
Currently, SigarRegistry is registered whenever SystemMetricsMonitor is
restarted. But it is wrong, it causes InstanceAlreadyExistsException
when SystemMetricsMontor restarts.
