### PR TITLE
Add native library directory before server starts.

### DIFF
--- a/app/beyond/Global.scala
+++ b/app/beyond/Global.scala
@@ -18,6 +18,7 @@ import play.api.mvc.Results.NotFound
 import play.api.mvc.SimpleResult
 import play.api.mvc.WithFilters
 import scala.concurrent.Future
+import scalax.file.Path
 
 private object TimeoutFilter extends Filter {
   def apply(next: (RequestHeader) => Future[SimpleResult])(request: RequestHeader): Future[SimpleResult] = {
@@ -51,6 +52,15 @@ object Global extends WithFilters(TimeoutFilter) with Logging {
 
     val finalConfiguration = defaultConfig ++ modeSpecificConfiguration
     super.onLoadConfig(finalConfiguration, path, classLoader, mode)
+  }
+
+  override def beforeStart(app: Application) {
+    super.beforeStart(app)
+
+    val nativeLib = Path.fromString(app.path.getAbsolutePath) / "target" / "native_libraries" / (System.getProperty("sun.arch.data.model") + "bits")
+    val defaultLibPath = System.getProperty("java.library.path")
+    val newLibPath = defaultLibPath + File.pathSeparator + nativeLib.path
+    System.setProperty("java.library.path", newLibPath)
   }
 
   override def onStart(app: Application) {


### PR DESCRIPTION
Currently, only development mode(play run) runs well with sigar, because
sbt extracts native library files into `target/native_libraries/*bits',
and only development mode(play run) has this path in java.library.path.

This patch adds the native library directory into java.library.path
before server starts. But I'm not sure this is proper way to use JNI in
Play Framework. There is no documentation about it.
