### PR TITLE
Install require unconditionally.

### DIFF
--- a/app/beyond/plugin/BeyondJavaScriptEngine.scala
+++ b/app/beyond/plugin/BeyondJavaScriptEngine.scala
@@ -3,21 +3,26 @@ package beyond.plugin
 import beyond.BeyondConfiguration
 import com.typesafe.scalalogging.slf4j.{ StrictLogging => Logging }
 import org.mozilla.javascript.Context
+import org.mozilla.javascript.commonjs.module.Require
 import org.mozilla.javascript.Scriptable
 
-class BeyondJavaScriptEngine(val global: BeyondGlobal = new BeyondGlobal) extends Logging {
+class BeyondJavaScriptEngine(val global: BeyondGlobal = new BeyondGlobal,
+    pluginPaths: Seq[String] = BeyondConfiguration.pluginPaths) extends Logging {
   import com.beyondframework.rhino.RhinoConversions._
 
   val contextFactory: BeyondContextFactory = new BeyondContextFactory(new BeyondContextFactoryConfig)
 
-  contextFactory.call { cx: Context => global.init(cx); Unit }
+  private val require: Require = contextFactory.call { cx: Context =>
+    global.init(cx)
 
-  def load(filename: String): Scriptable = contextFactory.call { cx: Context =>
     // Sandboxed means that the require function doesn't have the "paths"
     // property, and also that the modules it loads don't export the
     // "module.uri" property.
     val sandboxed = true
-    val require = global.installRequire(cx, BeyondConfiguration.pluginPaths, sandboxed)
+    global.installRequire(cx, pluginPaths, sandboxed)
+  }.asInstanceOf[Require]
+
+  def loadMain(filename: String): Scriptable = contextFactory.call { cx: Context =>
     require.requireMain(cx, filename)
   }.asInstanceOf[Scriptable]
 }

--- a/app/beyond/plugin/GamePlugin.scala
+++ b/app/beyond/plugin/GamePlugin.scala
@@ -24,7 +24,7 @@ class GamePlugin(filename: String) extends Actor with ActorLogging {
   private val engine = new BeyondJavaScriptEngine
 
   private val handler: Function = engine.contextFactory.call { cx: Context =>
-    val exports = engine.load(filename)
+    val exports = engine.loadMain(filename)
     // FIXME: Don't hardcode the name of handler function.
     val handler = exports.get("handle", exports)
     handler match {

--- a/app/beyond/tool/JavaScriptShellConsole.scala
+++ b/app/beyond/tool/JavaScriptShellConsole.scala
@@ -12,6 +12,7 @@ import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
 import org.mozilla.javascript.tools.ToolErrorReporter
 import scala.annotation.tailrec
+import scalax.file.Path
 
 class FlexibleCompletor(global: Scriptable) extends Completer {
   private object DottedName {
@@ -76,7 +77,12 @@ object JavaScriptShellConsole extends App {
 
   val scope = new BeyondShellGlobal
 
-  val engine = new BeyondJavaScriptEngine(scope)
+  val pluginPaths = Seq(
+    Path.fromString(System.getProperty("user.dir")) / "plugins",
+    Path.fromString(System.getProperty("user.dir")) / "plugins" / "lib"
+  )
+
+  val engine = new BeyondJavaScriptEngine(scope, pluginPaths = pluginPaths.map(_.path))
 
   val errorReporter = new ToolErrorReporter(false, System.err)
   engine.contextFactory.setErrorReporter(errorReporter)


### PR DESCRIPTION
Currently, require is installed after loading the main script. Change the
behavior to install require unconditionally so that JavaScriptShellConsole can
use require.

This patch also changes BeyondJavaScriptEngine to take plugin paths as an
argument because JavaScriptShellConsole can't access
BeyondConfiguration.pluginPaths.
