### PR TITLE
Change package paths in the javascript files.

### DIFF
--- a/plugins/lib/console.js
+++ b/plugins/lib/console.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-importClass(Packages.beyond.plugin.lib.PluginConsole);
+importClass(Packages.beyond.engine.javascript.lib.PluginConsole);
 var nativeConsole = new PluginConsole();
 exports.log = function () {
     var message = util.format.apply(util.format, arguments);

--- a/plugins/lib/event.js
+++ b/plugins/lib/event.js
@@ -1,5 +1,5 @@
 var util = require('util');
-importClass(Packages.beyond.plugin.lib.PluginEvent);
+importClass(Packages.beyond.engine.javascript.lib.PluginEvent);
 var nativeEvent = new PluginEvent();
 exports.track = function (tag) {
     var formatString,


### PR DESCRIPTION
The previous patch has a bug. Console and Event library use hard coded
package paths, so these paths had to be change when refactroing.
