### PR TITLE
Scalastyle linting in admin submodule and travis-ci suggestion.

### DIFF
--- a/modules/admin/app/controllers/admin/Admin.scala
+++ b/modules/admin/app/controllers/admin/Admin.scala
@@ -21,7 +21,7 @@ object Admin extends Controller with MongoController {
 
   private class AuthenticatedRequest[A](val username: String, request: Request[A]) extends WrappedRequest[A](request)
   private object AuthenticatedAction extends ActionBuilder[AuthenticatedRequest] {
-    def invokeBlock[A](request: Request[A], block: (AuthenticatedRequest[A]) => Future[Result]) = {
+    def invokeBlock[A](request: Request[A], block: (AuthenticatedRequest[A]) => Future[Result]): Future[Result] = {
       request.session.get("username").map { username =>
         block(new AuthenticatedRequest(username, request))
       } getOrElse {


### PR DESCRIPTION
Fixed a lint error in the last version-up commit.

And I would suggest using not only `sbt test`, but also `sbt scalastyle` in travis-ci to check each commit's lint errors before merging it.

Now, there're too many lint errors in beyond core, so when they're cleared, we can start a work to check scalastyle in travis-ci, I think.
