### PR TITLE
Add `scalacOptions` to build.sbt.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,5 +44,6 @@ scalariformSettings
 Common.settings
 
 scalacOptions ++= Seq(
-  "-feature"
+  "-feature",
+  "-language:reflectiveCalls"
 )


### PR DESCRIPTION
`-feature` option is for displaying warnings properly when building the
project.

`-language:reflectiveCalls` is a flag for `reflectiveCalls`, which is
added to remove warning messages from `routes`.
