### PR TITLE
Change the result type of ScriptableCollection.insert().

### DIFF
--- a/plugins/examples/db.js
+++ b/plugins/examples/db.js
@@ -10,7 +10,13 @@ var schema = new db.Schema(1, {
 var collection = new Collection("example.keyValue", schema);
 
 exports.insert = function (key, value) {
-    return collection.insert({key: key, value: value, time: new Date()}).onComplete(console.log);
+    return collection.insert({key: key, value: value, time: new Date()})
+        .onFailure(console.error)
+        .onSuccess(function (doc) {
+            console.info(
+                "New document{ _id: %s, key: %s, value: %s, time: %s } is inserted.",
+                doc.objectID, doc.key(), doc.value(), doc.time());
+        });
 }
 
 exports.find = function () {


### PR DESCRIPTION
Currently, insert method returns Future of LastErrorMessage. But the
inserted document(include object id) is more nedded when the succeded.

This patch changes the result type of insert method to Future of
ScriptableDocument.
