### PR TITLE
Fix style errors.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala
+++ b/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala
@@ -6,25 +6,31 @@ import beyond.engine.javascript.JSFunction
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.annotations.JSStaticFunction
 
 object ScriptableConsole {
-  def jsStaticFunction_log(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
+  @JSStaticFunction
+  def log(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
     context.asInstanceOf[BeyondContext].console.log(args(0).asInstanceOf[String])
   }
 
-  def jsStaticFunction_info(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
+  @JSStaticFunction
+  def info(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
     context.asInstanceOf[BeyondContext].console.info(args(0).asInstanceOf[String])
   }
 
-  def jsStaticFunction_warn(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
+  @JSStaticFunction
+  def warn(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
     context.asInstanceOf[BeyondContext].console.warn(args(0).asInstanceOf[String])
   }
 
-  def jsStaticFunction_debug(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
+  @JSStaticFunction
+  def debug(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
     context.asInstanceOf[BeyondContext].console.debug(args(0).asInstanceOf[String])
   }
 
-  def jsStaticFunction_error(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
+  @JSStaticFunction
+  def error(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction) {
     context.asInstanceOf[BeyondContext].console.error(args(0).asInstanceOf[String])
   }
 

--- a/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala
+++ b/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala
@@ -11,6 +11,8 @@ import org.mozilla.javascript.RhinoException
 import org.mozilla.javascript.ScriptRuntime
 import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.annotations.{ JSFunction => JSFunctionAnnotation }
+import org.mozilla.javascript.annotations.JSStaticFunction
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Failure
@@ -27,26 +29,30 @@ object ScriptableFuture {
     }
   }
 
-  def jsStaticFunction_successful(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSStaticFunction
+  def successful(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     val newFuture = Future.successful(args(0))
     ScriptableFuture(context, newFuture)
   }
 
-  def jsStaticFunction_sequence(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSStaticFunction
+  def sequence(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val futures: Seq[Future[AnyRef]] = args.map(_.asInstanceOf[ScriptableFuture].future).toSeq
     val newFuture: Future[JSArray] = Future.sequence(futures).map(_.toArray)
     ScriptableFuture(context, newFuture)
   }
 
-  def jsStaticFunction_firstCompletedOf(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSStaticFunction
+  def firstCompletedOf(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val futures: Seq[Future[AnyRef]] = args.map(_.asInstanceOf[ScriptableFuture].future).toSeq
     val newFuture: Future[AnyRef] = Future.firstCompletedOf(futures)
     ScriptableFuture(context, newFuture)
   }
 
-  def jsFunction_onComplete(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def onComplete(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val thisFuture = thisObj.asInstanceOf[ScriptableFuture]
@@ -64,7 +70,8 @@ object ScriptableFuture {
     thisFuture
   }
 
-  def jsFunction_onSuccess(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def onSuccess(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val thisFuture = thisObj.asInstanceOf[ScriptableFuture]
@@ -76,7 +83,8 @@ object ScriptableFuture {
     thisFuture
   }
 
-  def jsFunction_onFailure(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def onFailure(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val thisFuture = thisObj.asInstanceOf[ScriptableFuture]
@@ -91,7 +99,8 @@ object ScriptableFuture {
     thisFuture
   }
 
-  def jsFunction_map(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def map(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val newFuture = thisObj.asInstanceOf[ScriptableFuture].future.map { result =>
@@ -102,7 +111,8 @@ object ScriptableFuture {
     ScriptableFuture(context, newFuture)
   }
 
-  def jsFunction_flatMap(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def flatMap(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val newFuture = thisObj.asInstanceOf[ScriptableFuture].future.flatMap { result =>
@@ -125,7 +135,8 @@ object ScriptableFuture {
     ScriptableFuture(context, newFuture)
   }
 
-  def jsFunction_filter(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def filter(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val newFuture = thisObj.asInstanceOf[ScriptableFuture].future.filter { result =>
@@ -137,7 +148,8 @@ object ScriptableFuture {
     ScriptableFuture(context, newFuture)
   }
 
-  def jsFunction_recover(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def recover(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val callback = args(0).asInstanceOf[JSFunction]
     val newFuture = thisObj.asInstanceOf[ScriptableFuture].future.recover {
@@ -152,7 +164,8 @@ object ScriptableFuture {
     ScriptableFuture(context, newFuture)
   }
 
-  def jsFunction_transform(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+  @JSFunctionAnnotation
+  def transform(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val thisFuture = thisObj.asInstanceOf[ScriptableFuture]
     val promise = Promise[AnyRef]()

--- a/core/app/beyond/engine/javascript/lib/ScriptableUUID.scala
+++ b/core/app/beyond/engine/javascript/lib/ScriptableUUID.scala
@@ -6,9 +6,11 @@ import java.util.UUID
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.annotations.JSStaticFunction
 
 object ScriptableUUID {
-  def jsStaticFunction_v4(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): String =
+  @JSStaticFunction
+  def v4(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): String =
     UUID.randomUUID().toString
 
   def jsConstructor(context: Context, args: JSArray, constructor: JSFunction, inNewExpr: Boolean): ScriptableUUID =

--- a/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala
@@ -11,9 +11,10 @@ import reactivemongo.bson.BSONArray
 import reactivemongo.bson.BSONDocument
 
 object ScriptableQuery {
-  // Cannot find eq method when @JSFunction annotation is used
-  // because static forwarder is not generated when the same name method exists in the class and companion object.
-  def jsFunction_eq(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
+  // Cannot use name eq because static forwarder is not generated
+  // when the same name method exists in the class and companion object.
+  @JSFunctionAnnotation("eq")
+  def jsEq(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
     val value = args(1)


### PR DESCRIPTION
This patch fixes below style errrors.

error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=16 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableUUID.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=11 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=30 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=35 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=42 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=49 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=79 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=94 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=105 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=128 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=140 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableFuture.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=155 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=11 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=15 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=19 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]_$' line=23 column=6
error file=/home/sloan/workspace/beyond/core/app/beyond/engine/javascript/lib/ScriptableConsole.scala message=Method name does not match the regular expression '^[a-z][A-Za-z0-9]*$' line=27 column=6
