### PR TITLE
Make reference field return ObjectID.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
@@ -86,15 +86,7 @@ class ScriptableDocument(fields: Seq[Field], currentValuesInDB: BSONDocument) ex
     override def call(cx: Context, scope: Scriptable, thisObj: Scriptable, args: JSArray): AnyRef = {
       args match {
         case Array() =>
-          (currentJavaScriptValue(name)(cx, scope), fieldByName(name)) match {
-            case (nativeObjectID: NativeJavaObject, ReferenceField(_, collection)) =>
-              val objectID = nativeObjectID.unwrap().asInstanceOf[ObjectID].bson
-              val query: JSArray = Array(ScriptableQuery(cx, BSONDocument("_id" -> objectID)))
-              // reference type field returns the future of document.
-              ScriptableCollection.findOne(cx, collection, query, null)
-            case (javaScriptValue, _) =>
-              javaScriptValue
-          }
+          currentJavaScriptValue(name)(cx, scope)
         case Array(arg) =>
           implicit val field = fieldByName(name)
           val scalaValue = convertJavaScriptToScalaWithField(arg)

--- a/plugins/examples/db.js
+++ b/plugins/examples/db.js
@@ -134,7 +134,8 @@ exports.referenceInsert = function (key) {
 exports.referenceFindOne = function (key) {
     var query = db.query().eq("key", key);
     return collection2.findOne(query).flatMap(function (result) {
-        return result.ref();
+        var query = db.query().eq("_id", result.ref())
+        return collection.findOne(query);
     }).onSuccess(function (result) {
         console.log("Found data: %j", result);
     }).onFailure(function (message) {
@@ -156,7 +157,8 @@ exports.referenceUpdate = function (key1, key2) {
         }).onFailure(function (message) {
             console.error("Cannot find document2: %s", message);
         }).flatMap(function (document2) {
-            return document2.ref().onSuccess(function (result) {
+            var query = db.query().eq("_id", document2.ref())
+            return collection.findOne(query).onSuccess(function (result) {
                 console.log("document2.ref: %j", result);
             }).onFailure(function (message) {
                 console.error("Cannot find documennt2.ref: %s", message);


### PR DESCRIPTION
Currently, reference field returns Future of document. But some cases
just need the object id not the document.
This patch makes reference fied return ObjectID. When a user needs the
document, the user have to call findOne with it.
