### PR TITLE
Make collection.save method return Future of document on success.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
@@ -129,4 +129,13 @@ class ScriptableDocument(fields: Seq[Field], currentValuesInDB: BSONDocument) ex
     }
     obj
   }
+
+  def currentBSONDocument: BSONDocument = {
+    val modifiedDocument = modifier
+    val currentElements = currentValuesInDB.elements.filter {
+      case (key, _) =>
+        modifiedDocument.get(key) == None
+    } ++ modifiedDocument.elements
+    BSONDocument(currentElements)
+  }
 }

--- a/plugins/examples/db.js
+++ b/plugins/examples/db.js
@@ -106,7 +106,9 @@ exports.save = function () {
             console.error(util.format("Cannot find data. ERROR: %s", result));
         }
     }).flatMap(function (result) {
-        return collection.save(result.value(newValue).time(new Date())).onComplete(console.log);
+        return collection.save(result.value(newValue).time(new Date())).onComplete(console.log).onSuccess(function (doc) {
+            console.log("%j", doc);
+        });
     });
 };
 


### PR DESCRIPTION
Currently save method returns Future of LastErrorMessage. But in the
most case of success the updated document is needed.

This patch makes save method return Future of document on success.
