### PR TITLE
Do not convert to NativeObject if it is the primitive type.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
@@ -102,7 +102,7 @@ class ScriptableDocument(fields: Seq[Field], currentValuesInDB: BSONDocument) ex
 
   private def fieldByName(name: String): Field = fields.find(_.name == name).get
 
-  private def currentJavaScriptValue(name: String)(implicit context: Context, scope: Scriptable): Scriptable = {
+  private def currentJavaScriptValue(name: String)(implicit context: Context, scope: Scriptable): AnyRef = {
     val bsonValue = currentBSONValue(name)
     val scalaValue = AnyRefBSONHandler.read(bsonValue)
     convertScalaToJavaScript(scalaValue)(context, scope)

--- a/core/app/beyond/engine/javascript/lib/database/package.scala
+++ b/core/app/beyond/engine/javascript/lib/database/package.scala
@@ -104,22 +104,13 @@ package object database {
   private[database] case class ReferenceField(override val name: String, collection: ScriptableCollection) extends Field
   private[database] case class EmbeddingField(override val name: String, schema: ScriptableSchema) extends Field
 
-  private[database] def convertScalaToJavaScript(value: AnyRef)(implicit context: Context, scope: Scriptable): Scriptable = value match {
-    case i: jl.Integer =>
-      val args: JSArray = Array(Double.box(i.toDouble))
-      context.newObject(scope, "Number", args)
-    case j: jl.Long =>
-      val args: JSArray = Array(Double.box(j.toDouble))
-      context.newObject(scope, "Number", args)
-    case d: jl.Double =>
-      val args: JSArray = Array(Double.box(d))
-      context.newObject(scope, "Number", args)
+  private[database] def convertScalaToJavaScript(value: AnyRef)(implicit context: Context, scope: Scriptable): AnyRef = value match {
+    case number: jl.Number =>
+      number
     case str: String =>
-      val args: JSArray = Array(str)
-      context.newObject(scope, "String", args)
-    case b: jl.Boolean =>
-      val args: JSArray = Array(b)
-      context.newObject(scope, "Boolean", args)
+      str
+    case boolean: jl.Boolean =>
+      boolean
     case date: Date =>
       val args: JSArray = Array(Long.box(date.getTime))
       context.newObject(scope, "Date", args)


### PR DESCRIPTION
Currently, the field type of the Document is object not expected(string,
number and boolean) because ScriptableDocument converts it to
NativeObject.

This patch makes ScriptableDocument reuturn the primitve type itself.
Rhino engine will automatically convert Number, Boolean and String because
BeyondContextFactory set javaPrimitiveWrap as false.
