### PR TITLE
Fix bugs when save the document without change data.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
@@ -157,11 +157,15 @@ class ScriptableCollection(name: String, schema: ScriptableSchema) extends Scrip
   private def saveInternal(dataToBeUpdated: ScriptableDocument)(implicit ec: ExecutionContext): Future[BSONDocument] = {
     val objectID = BSONDocument("_id" -> dataToBeUpdated.objectID)
     val modifier = BSONDocument("$set" -> dataToBeUpdated.modifier)
-    collection.update(objectID, modifier).map {
-      case lastError if lastError.inError =>
-        throw new Exception(lastError.message)
-      case _ =>
-        dataToBeUpdated.currentBSONDocument
+    if (modifier.isEmpty) {
+      Future.successful(dataToBeUpdated.currentBSONDocument)
+    } else {
+      collection.update(objectID, modifier).map {
+        case lastError if lastError.inError =>
+          throw new Exception(lastError.message)
+        case _ =>
+          dataToBeUpdated.currentBSONDocument
+      }
     }
   }
 }


### PR DESCRIPTION
Currently, ScriptableCollection.save method requests update the document
even though there is no changed data.
It makes no error on linux, but makes an error on mac.

This patch makes ScriptableCollection.save method requests only when
there is a changed data.
