### PR TITLE
Make ScriptableQuery handle ScriptableObjectId.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala
@@ -18,7 +18,7 @@ object ScriptableQuery {
   def jsEq(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
-    val value = args(1)
+    val value = parseValue(args(1))
     val newQuery: BSONDocument = currentQuery.add(field -> value)
     ScriptableQuery(context, newQuery)
   }
@@ -27,7 +27,7 @@ object ScriptableQuery {
   def neq(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
-    val value = args(1)
+    val value = parseValue(args(1))
     val newQuery: BSONDocument = currentQuery.add(field -> BSONDocument("$ne" -> value))
     ScriptableQuery(context, newQuery)
   }
@@ -36,7 +36,7 @@ object ScriptableQuery {
   def lt(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
-    val value = args(1)
+    val value = parseValue(args(1))
     val newQuery: BSONDocument = currentQuery.add(field -> BSONDocument("$lt" -> value))
     ScriptableQuery(context, newQuery)
   }
@@ -45,7 +45,7 @@ object ScriptableQuery {
   def lte(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
-    val value = args(1)
+    val value = parseValue(args(1))
     val newQuery: BSONDocument = currentQuery.add(field -> BSONDocument("$lte" -> value))
     ScriptableQuery(context, newQuery)
   }
@@ -54,7 +54,7 @@ object ScriptableQuery {
   def gt(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
-    val value = args(1)
+    val value = parseValue(args(1))
     val newQuery: BSONDocument = currentQuery.add(field -> BSONDocument("$gt" -> value))
     ScriptableQuery(context, newQuery)
   }
@@ -63,7 +63,7 @@ object ScriptableQuery {
   def gte(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableQuery = {
     val currentQuery: BSONDocument = thisObj.asInstanceOf[ScriptableQuery].query
     val field = args(0).asInstanceOf[String]
-    val value = args(1)
+    val value = parseValue(args(1))
     val newQuery: BSONDocument = currentQuery.add(field -> BSONDocument("$gte" -> value))
     ScriptableQuery(context, newQuery)
   }
@@ -100,6 +100,13 @@ object ScriptableQuery {
     val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
     val scope = beyondContextFactory.global
     context.newObject(scope, "Query", bson).asInstanceOf[ScriptableQuery]
+  }
+
+  private def parseValue(value: AnyRef): AnyRef = value match {
+    case obj: ScriptableObjectId =>
+      ObjectId(obj.bson)
+    case _ =>
+      value
   }
 }
 


### PR DESCRIPTION
Currently, ScriptableQuery cannot handle ScriptableObjectId, because it
uses AnyRefBSONHandler directly. We need to make AnyRefBSONHandler
handle ScriptableObjectId or ScriptableQuery changes ScriptableObjectId
to ObjectId before using AnyRefBSONHandler.

I decided the second choice because AnyRefBSONHandler is used by
ScriptableDocument with convertJavaScriptToScalaWithField method. And
ScriptableObjectId is not passed to AnyRefBSONHandler in this case.
