### PR TITLE
Add count command on DB API.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
@@ -13,6 +13,7 @@ import org.mozilla.javascript.annotations.{ JSFunction => JSFunctionAnnotation }
 import reactivemongo.api.collections.default.BSONCollection
 import reactivemongo.bson.BSONDocument
 import reactivemongo.bson.BSONObjectID
+import reactivemongo.core.commands.Count
 import reactivemongo.core.commands.LastError
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -70,6 +71,17 @@ object ScriptableCollection {
         }
     }
     ScriptableFuture(context, convertedToScriptableDocumentResult)
+  }
+
+  @JSFunctionAnnotation
+  def count(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+    implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
+    val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
+    val thisCollection = thisObj.asInstanceOf[ScriptableCollection]
+    val countQuery = args(0).asInstanceOf[ScriptableQuery]
+    val countResult = thisCollection.countInternal(countQuery)
+
+    ScriptableFuture(context, countResult)
   }
 
   @JSFunctionAnnotation
@@ -173,6 +185,9 @@ class ScriptableCollection(name: String, schema: ScriptableSchema) extends Scrip
       Future.failed(new IllegalArgumentException("Cannot pass validations."))
     }
   }
+
+  private def countInternal(query: ScriptableQuery)(implicit ec: ExecutionContext): Future[Int] =
+    collection.db.command(Count(collectionName = name, query = Option(query.query)))
 
   private def validateDocument(document: BSONDocument): Boolean =
     fields.forall {

--- a/plugins/examples/db.js
+++ b/plugins/examples/db.js
@@ -226,3 +226,13 @@ exports.arrayFindOne = function(key) {
         console.log("%j", doc);
     });
 };
+
+exports.count = function () {
+    var queries = Array.prototype.slice.call(arguments, 0).map(function (arg) {
+        return db.query("key", arg);
+    });
+    var emptyQuery = db.query();
+    var baseQuery = queries.shift();
+    var q = baseQuery.or.apply(baseQuery, queries);
+    return collection.count(q).onComplete(console.log);
+};

--- a/plugins/main.js
+++ b/plugins/main.js
@@ -84,6 +84,9 @@ exports.handle = function (req) {
         case "findOne":
             db.findOne.apply(db.findOne, tokens);
             break;
+        case "count":
+            db.count.apply(db.count, tokens);
+            break;
         case "referenceFindOne":
             db.referenceFindOne(tokens[0]);
             break;


### PR DESCRIPTION
This API can be used as find or findOne, but it returns the number of
the document.
It uses count command internally, so it's more efficient than using find
and getting the length of the find result.

And this patch also adds an example.
