### PR TITLE
Make removeOne method consume ScriptableDocument.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
@@ -85,7 +85,12 @@ object ScriptableCollection {
   def removeOne(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
     val thisCollection = thisObj.asInstanceOf[ScriptableCollection]
-    val removeQuery = args(0).asInstanceOf[ScriptableQuery]
+    val removeQuery = args match {
+      case Array(query: ScriptableQuery) => query
+      case Array(document: ScriptableDocument) =>
+        ScriptableQuery(context, "_id", document.getObjectId)
+      case _ => throw new IllegalArgumentException("Collection.remove method can receive query and document")
+    }
     val removeResult = thisCollection.removeInternal(removeQuery, firstMatchOnly = true)
     ScriptableFuture(context, removeResult)
   }

--- a/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableQuery.scala
@@ -104,6 +104,12 @@ object ScriptableQuery {
     context.newObject(scope, "Query", bson).asInstanceOf[ScriptableQuery]
   }
 
+  private[database] def apply(context: Context, name: String, value: AnyRef): ScriptableQuery = {
+    val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
+    val scope = beyondContextFactory.global
+    context.newObject(scope, "Query", name, value).asInstanceOf[ScriptableQuery]
+  }
+
   private def convertToInternalRepresentation(value: AnyRef): AnyRef = value match {
     case obj: ScriptableObjectId =>
       ObjectId(obj.bson)


### PR DESCRIPTION
Currently, removeOne method only consumes query. This patch makes the
method also consumes document too.
