### PR TITLE
Add orderBy method to DB API.

### DIFF
--- a/plugins/lib/db.js
+++ b/plugins/lib/db.js
@@ -12,3 +12,6 @@ exports.Schema = Schema;
 exports.ObjectId = function(value) {
     return value ? new ObjectId(value) : new ObjectId();
 };
+
+exports.ASC = 1;
+exports.DESC = -1;


### PR DESCRIPTION
This patch orderBy method to Collection. This method return new
collection that returns the sorted result.

For example, `collection.orderBy('fieldName', db.ASC)' will be new
collection that returns the result with sorted by fieldName in ascending
order.

If you want the result sorted by `field1' in ascending and`field2' in
descending, you have to call orderBy twice like
`collection.orderBy('field2', db.DESC).orderBy('field1', db.ASC)'.

If you call orderBy tiwce with the same field, the last one will be
applied. In other words,
`collection.orderBy('fieldName', db.DESC).orderBy('fieldName', db.ASC)'
will retrun the result in ascending.
