### PR TITLE
Add a sbt task to run JavaScript console.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,10 @@ testScalaStyle := {
 
 (test in Test) <<= (test in Test) dependsOn testScalaStyle
 
+lazy val jsConsole = TaskKey[Unit]("js-console", "JavaScript shell console in Beyond")
+
+fullRunTask(jsConsole, Compile, "beyond.tool.JavaScriptShellConsole")
+
 scalariformSettings
 
 Common.settings


### PR DESCRIPTION
The task launches JavaScriptShellConsole in beyond.tool, which means the console can be started with `activator js-console` or `sbt js-console`.
