### PR TITLE
Add ScriptableHttpClient.

### DIFF
--- a/core/app/beyond/engine/javascript/BeyondGlobal.scala
+++ b/core/app/beyond/engine/javascript/BeyondGlobal.scala
@@ -13,6 +13,8 @@ import beyond.engine.javascript.lib.database.ScriptableSchema
 import beyond.engine.javascript.lib.filesystem.ScriptableFile
 import beyond.engine.javascript.lib.filesystem.ScriptableFileSystem
 import beyond.engine.javascript.lib.filesystem.ScriptablePath
+import beyond.engine.javascript.lib.http.ScriptableHttpClient
+import beyond.engine.javascript.lib.http.ScriptableHttpResult
 import beyond.engine.javascript.lib.http.ScriptableRequest
 import beyond.engine.javascript.lib.http.ScriptableResponse
 import java.io.File
@@ -117,6 +119,8 @@ class BeyondGlobal extends ImporterTopLevel {
       classOf[ScriptableFileSystem],
       classOf[ScriptableFile],
       classOf[ScriptableFuture],
+      classOf[ScriptableHttpClient],
+      classOf[ScriptableHttpResult],
       classOf[ScriptableObjectId],
       classOf[ScriptablePath],
       classOf[ScriptableQuery],

--- a/core/app/beyond/engine/javascript/lib/http/ScriptableHttpClient.scala
+++ b/core/app/beyond/engine/javascript/lib/http/ScriptableHttpClient.scala
@@ -1,0 +1,201 @@
+package beyond.engine.javascript.lib.http
+
+import beyond.engine.javascript.BeyondContextFactory
+import beyond.engine.javascript.JSArray
+import beyond.engine.javascript.JSFunction
+import beyond.engine.javascript.lib.ScriptableFuture
+import com.beyondframework.rhino.ContextOps._
+import java.io.File
+import org.mozilla.javascript.Context
+import org.mozilla.javascript.ScriptRuntime
+import org.mozilla.javascript.Scriptable
+import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.annotations.{ JSFunction => JSFunctionAnnotation }
+import org.mozilla.javascript.annotations.JSStaticFunction
+import play.{ api => playApi }
+import play.api.libs.json._
+import play.api.libs.ws._
+import scala.concurrent.Future
+import scalaz.syntax.std.boolean._
+
+object ScriptableHttpClient {
+  private[lib] def apply(context: Context, url: String, method: String): ScriptableHttpClient = {
+    val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
+    val scope = beyondContextFactory.global
+    context.newObject(scope, "HttpClient", url, method).asInstanceOf[ScriptableHttpClient]
+  }
+
+  def jsConstructor(context: Context, args: JSArray, constructor: JSFunction, inNewExpr: Boolean): ScriptableHttpClient = {
+    val url: String = args(0).asInstanceOf[String]
+    val method: String = args(1).asInstanceOf[String]
+
+    new ScriptableHttpClient(url, method)
+  }
+
+  private def convertScriptableToSeq(scriptable: Scriptable): Seq[(String, String)] =
+    scriptable.getIds.map {
+      case key: String =>
+        key -> ScriptRuntime.toString(scriptable.get(key, scriptable))
+    }
+
+  @JSFunctionAnnotation
+  def set(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient = {
+    val thisHttpClient = thisObj.asInstanceOf[ScriptableHttpClient]
+    val headers = args(0).asInstanceOf[Scriptable]
+
+    thisHttpClient.setHeaders(convertScriptableToSeq(headers))
+    thisHttpClient
+  }
+
+  @JSFunctionAnnotation
+  def query(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient = {
+    val thisHttpClient = thisObj.asInstanceOf[ScriptableHttpClient]
+    val parameters = args(0).asInstanceOf[Scriptable]
+
+    thisHttpClient.setQueryString(convertScriptableToSeq(parameters))
+    thisHttpClient
+  }
+
+  private def convertScriptableToForm(scriptable: Scriptable): Map[String, Seq[String]] =
+    scriptable.getIds.map {
+      case key: String =>
+        scriptable.get(key, scriptable) match {
+          case value: String =>
+            key -> Seq(value)
+          case values: Scriptable =>
+            key -> ScriptRuntime.getArrayElements(values).map(_.asInstanceOf[String]).toSeq
+        }
+    }.toMap
+
+  @JSFunctionAnnotation
+  def send(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient = {
+    val thisHttpClient = thisObj.asInstanceOf[ScriptableHttpClient]
+    val form = args(0).asInstanceOf[Scriptable]
+
+    thisHttpClient.setFormBody(convertScriptableToForm(form))
+    thisHttpClient
+  }
+
+  private def convertScriptableToJsObject(scriptable: Scriptable): JsObject = {
+    val jsonSeq: Seq[(String, JsValue)] = scriptable.getIds.map {
+      case key: String =>
+        scriptable.get(key, scriptable) match {
+          case number: Integer =>
+            key -> JsNumber(number.toInt)
+          case number: java.lang.Double =>
+            key -> JsNumber(BigDecimal(number))
+          case string: String =>
+            key -> JsString(string)
+          case obj: Scriptable =>
+            key -> convertScriptableToJsObject(obj)
+        }
+    }
+
+    JsObject(jsonSeq)
+  }
+
+  @JSFunctionAnnotation
+  def json(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient = {
+    val thisHttpClient = thisObj.asInstanceOf[ScriptableHttpClient]
+    val json = args(0).asInstanceOf[Scriptable]
+
+    thisHttpClient.setJsonBody(convertScriptableToJsObject(json))
+    thisHttpClient
+  }
+
+  private val defaultAuthScheme: WSAuthScheme = WSAuthScheme.BASIC
+
+  private def authSchemeForName(name: String): WSAuthScheme = name match {
+    case "basic" => WSAuthScheme.BASIC
+    case "digest" => WSAuthScheme.DIGEST
+    case "kerberos" => WSAuthScheme.KERBEROS
+    case "none" => WSAuthScheme.NONE
+    case "ntlm" => WSAuthScheme.NTLM
+    case "spnego" => WSAuthScheme.SPNEGO
+  }
+
+  @JSFunctionAnnotation
+  def auth(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient = {
+    val thisHttpClient = thisObj.asInstanceOf[ScriptableHttpClient]
+    val username = args(0).asInstanceOf[String]
+    val password = args(1).asInstanceOf[String]
+    val scheme = args.isDefinedAt(2) ? authSchemeForName(args(2).asInstanceOf[String]) | defaultAuthScheme
+
+    thisHttpClient.setAuth(username, password, scheme)
+    thisHttpClient
+  }
+
+  @JSFunctionAnnotation
+  def end(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+    val thisHttpClient = thisObj.asInstanceOf[ScriptableHttpClient]
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    ScriptableFuture(context, thisHttpClient.execute().map(ScriptableHttpResult(context, _)))
+  }
+
+  @JSStaticFunction("get")
+  def jsGet(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "get")
+
+  @JSStaticFunction
+  def head(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "head")
+
+  @JSStaticFunction
+  def post(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "post")
+
+  @JSStaticFunction("put")
+  def jsPut(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "put")
+
+  @JSStaticFunction("delete")
+  def jsDelete(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "delete")
+
+  @JSStaticFunction
+  def options(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "options")
+
+  @JSStaticFunction
+  def patch(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableHttpClient =
+    ScriptableHttpClient(context, args(0).asInstanceOf[String], "patch")
+
+  // If there's no running application, create one.
+  // Mainly for test and console
+  lazy private val testApp =
+    new playApi.DefaultApplication(new File("."), this.getClass.getClassLoader, None, playApi.Mode.Test)
+}
+
+class ScriptableHttpClient(url: String, method: String) extends ScriptableObject {
+  implicit private val app = playApi.Play.maybeApplication.getOrElse(ScriptableHttpClient.testApp)
+
+  def this() = this("about:blank", "get")
+  def this(url: String) = this(url, "get")
+
+  override def getClassName: String = "HttpClient"
+
+  private var holder: WSRequestHolder = WS.url(url).withMethod(method.toUpperCase)
+
+  private def execute(): Future[WSResponse] = holder.execute()
+
+  private def setHeaders(headers: Seq[(String, String)]) {
+    holder = holder.withHeaders(headers: _*)
+  }
+
+  private def setQueryString(parameters: Seq[(String, String)]) {
+    holder = holder.withQueryString(parameters: _*)
+  }
+
+  private def setFormBody(form: Map[String, Seq[String]]) {
+    holder = holder.withBody(form)
+  }
+
+  private def setJsonBody(json: JsObject) {
+    holder = holder.withBody(json)
+  }
+
+  private def setAuth(username: String, password: String, scheme: WSAuthScheme) {
+    holder = holder.withAuth(username, password, scheme)
+  }
+}

--- a/core/app/beyond/engine/javascript/lib/http/ScriptableHttpResult.scala
+++ b/core/app/beyond/engine/javascript/lib/http/ScriptableHttpResult.scala
@@ -1,0 +1,64 @@
+package beyond.engine.javascript.lib.http
+
+import beyond.engine.javascript.BeyondContextFactory
+import beyond.engine.javascript.JSArray
+import beyond.engine.javascript.JSFunction
+import com.beyondframework.rhino.ContextOps._
+import org.mozilla.javascript.Context
+import org.mozilla.javascript.Scriptable
+import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.annotations.JSGetter
+import play.api.libs.ws._
+import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder
+
+object ScriptableHttpResult {
+  private[lib] def apply(context: Context, res: WSResponse): ScriptableHttpResult = {
+    val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
+    val scope = beyondContextFactory.global
+    context.newObject(scope, "HttpResult", res).asInstanceOf[ScriptableHttpResult]
+  }
+
+  def jsConstructor(context: Context, args: JSArray, constructor: JSFunction, inNewExpr: Boolean): ScriptableHttpResult = {
+    val res = args(0) match {
+      case wsResponse: WSResponse =>
+        wsResponse
+      case _ => throw new IllegalArgumentException("type.is.not.matched")
+    }
+
+    new ScriptableHttpResult(context, res)
+  }
+}
+
+class ScriptableHttpResult(context: Context, res: WSResponse) extends ScriptableObject {
+  def this() = this(null, null)
+
+  override def getClassName: String = "HttpResult"
+
+  @JSGetter
+  def status: Int = res.status
+
+  @JSGetter
+  def statusText: String = res.statusText
+
+  @JSGetter
+  def headers: Scriptable = {
+    val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
+    val scope = beyondContextFactory.global
+
+    val headerObj: Scriptable = context.newObject(scope)
+    res.allHeaders.foreach {
+      case (key, values) =>
+        val value: AnyRef =
+          if (values.length == 1) {
+            values(0)
+          } else {
+            context.newArray(scope, values.toArray)
+          }
+        headerObj.put(key, headerObj, value)
+    }
+    headerObj
+  }
+
+  @JSGetter
+  def body: String = res.body
+}

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -3,6 +3,7 @@ name := "core"
 resolvers += "spray repo" at "http://repo.spray.io"
 
 libraryDependencies ++= Seq(
+  ws,
   "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.2",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.2",
   "com.typesafe.akka" %% "akka-actor" % "2.2.4",

--- a/plugins/lib/http-client.js
+++ b/plugins/lib/http-client.js
@@ -1,0 +1,2 @@
+/* global HttpClient */
+module.exports = HttpClient;

--- a/plugins/test/http-client.js
+++ b/plugins/test/http-client.js
@@ -1,0 +1,204 @@
+var assert = require('assert');
+var request = require('http-client');
+require('bdd').mount(this);
+
+function complete(done, callback) {
+  return function (res, success) {
+    if (success) {
+      callback(res);
+    } else {
+      done('failed.');
+    }
+  };
+}
+
+describe('http-client', function () {
+  describe('#get()', function () {
+    var req;
+    beforeEach(function () {
+      req = request.get('http://httpbin.org/get?hello=world');
+    });
+
+    it.will('send a get request.', function (done) {
+      req
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.url, 'http://httpbin.org/get?hello=world');
+          });
+        }));
+    });
+
+    it.will('send a get request with query string in url.', function (done) {
+      req
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.args.hello, 'world');
+          });
+        }));
+    });
+
+    it.will('send a get request with query string with query().', function (done) {
+      req
+        .query({'query': 'string'})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.args.hello, 'world');
+            assert.equal(result.args.query, 'string');
+          });
+        }));
+    });
+
+    it.will('send a get request with headers.', function (done) {
+      req
+        .set({'Hello': 'world', 'Beyond': 'framework', 'Number': 1234})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.headers.Hello, 'world');
+            assert.equal(result.headers.Beyond, 'framework');
+            assert.equal(result.headers.Number, '1234');
+          });
+        }));
+    });
+  });
+
+  describe('#post()', function () {
+    var req;
+    beforeEach(function () {
+      req = request.post('http://httpbin.org/post');
+    });
+
+    it.will('send a post request.', function (done) {
+      req
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.url, 'http://httpbin.org/post');
+          });
+        }));
+    });
+
+    it.will('send a post request with form data.', function (done) {
+      req
+        .send({'hello': 'world', 'beyond': 'framework'})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.form.hello, 'world');
+            assert.equal(result.form.beyond, 'framework');
+          });
+        }));
+    });
+
+    it.will('send a post request with JSON data.', function (done) {
+      req
+        .json({'hello': 'world', 'beyond': 'framework'})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            var jsonData = JSON.parse(result.data);
+            assert.equal(jsonData.hello, 'world');
+            assert.equal(jsonData.beyond, 'framework');
+          });
+        }));
+    });
+
+    it.will('send a post request with headers.', function (done) {
+      req
+        .set({'Hello': 'world', 'Beyond': 'framework', 'Number': 1234})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.headers.Hello, 'world');
+            assert.equal(result.headers.Beyond, 'framework');
+            assert.equal(result.headers.Number, '1234');
+          });
+        }));
+    });
+  });
+
+  describe('#put()', function () {
+    var req;
+    beforeEach(function () {
+      req = request.put('http://httpbin.org/put');
+    });
+
+    it.will('send a put request.', function (done) {
+      req
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.url, 'http://httpbin.org/put');
+          });
+        }));
+    });
+
+    it.will('send a put request with form data.', function (done) {
+      req
+        .send({'hello': 'world', 'beyond': 'framework'})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.form.hello, 'world');
+            assert.equal(result.form.beyond, 'framework');
+          });
+        }));
+    });
+
+    it.will('send a put request with JSON data.', function (done) {
+      req
+        .json({'hello': 'world', 'beyond': 'framework'})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            var jsonData = JSON.parse(result.data);
+            assert.equal(jsonData.hello, 'world');
+            assert.equal(jsonData.beyond, 'framework');
+          });
+        }));
+    });
+
+    it.will('send a put request with headers.', function (done) {
+      req
+        .set({'Hello': 'world', 'Beyond': 'framework', 'Number': 1234})
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.headers.Hello, 'world');
+            assert.equal(result.headers.Beyond, 'framework');
+            assert.equal(result.headers.Number, '1234');
+          });
+        }));
+    });
+  });
+
+  describe('#auth()', function () {
+    it.will('send a request with basic auth.', function (done) {
+      request
+        .get('http://httpbin.org/basic-auth/hello/world')
+        .auth('hello', 'world')
+        .end()
+        .onComplete(complete(done, function (res) {
+          assert.async(done, function () {
+            var result = JSON.parse(res.body);
+            assert.equal(result.authenticated, true);
+          });
+        }));
+    });
+  });
+});


### PR DESCRIPTION
ScriptableHttpClient is the module to send HTTP request from the Beyond
plugin. It refers to Node's SuperAgent package for its API design.

The test case is added as plugins/test/http-client.js

Moved from #139.

Basic usage is like below:

``` javascript
var request = require('http-client');

// Example GET request
request
  .get('http://example.org') // create GET request. It also supports post, put, delete, etc.
  .query({'key': 'value'}) // query string for GET request
  .set({'Key': 'value'}) // headers
  .end() // execute request, return ScriptableFuture
  .onSuccess(function (res) {
    console.log(res.status); // Int
    console.log(res.statusText); // String
    console.log(res.body); // body text: String
    console.log(JSON.stringify(res.headers)); // headers as object
  });

// Example POST request
request
  .post('http://example.org') // create POST request.
  .send({'name': 'value'}) // form data
  .json({'key': 'value'}) // json data
  .auth('username', 'password') // auth
  .end()
  .onSuccess(function (res) {
    console.log(res.status); // Int
    console.log(res.statusText); // String
    console.log(res.body); // body text: String
    console.log(JSON.stringify(res.headers)); // headers as object
  });
```
