### PR TITLE
Change Scalastyle to work with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
   - npm install
   - npm install -g gulp
 script:
+  - sbt ++$TRAVIS_SCALA_VERSION scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION test
   - sbt ++$TRAVIS_SCALA_VERSION plugin-test
   - gulp

--- a/build.sbt
+++ b/build.sbt
@@ -30,15 +30,6 @@ lazy val rhinoScalaBinding = project
 
 org.scalastyle.sbt.ScalastylePlugin.Settings
 
-// Create a default Scala style task to run with tests
-lazy val testScalaStyle = taskKey[Unit]("testScalaStyle")
-
-testScalaStyle := {
-  org.scalastyle.sbt.PluginKeys.scalastyle.toTask("").value
-}
-
-(test in Test) <<= (test in Test) dependsOn testScalaStyle
-
 lazy val pluginTest = TaskKey[Unit]("plugin-test", "Plugin JavaScript API Test")
 
 fullRunTask(pluginTest, Compile, "beyond.plugin.test.TestRunner")


### PR DESCRIPTION
Scalastyle was intended to work with `sbt test`, but it didn't work.

This commit removes the lines in build.sbt for it and just adds the command in the Travis CI configuration file.
