### PR TITLE
Change objectId to _id.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
@@ -178,11 +178,11 @@ class ScriptableCollection(name: String, schema: ScriptableSchema) extends Scrip
   // Cannot use name 'insert', because static forwarder is not generated when the companion object and class have the same name method.
   private def insertInternal(obj: ScriptableObject)(implicit ec: ExecutionContext): Future[BSONDocument] = {
     val dataToBeInserted: BSONDocument = convertScriptableObjectToBSONDocument(obj)(schema.fields)
-    val objectId = Option(obj.get("objectId")).map {
+    val objectId = Option(obj.get("_id")).map {
       case objectId: ScriptableObjectId =>
         objectId.bson
       case somethingElse =>
-        throw new IllegalArgumentException(s"objectId should be ObjectId. $somethingElse is not ObjectId.")
+        throw new IllegalArgumentException(s"_id should be ObjectId. $somethingElse is not ObjectId.")
     }.getOrElse(BSONObjectID.generate)
     if (validateDocument(dataToBeInserted)) {
       val documentToBeInserted = BSONDocument("_id" -> objectId) ++ dataToBeInserted

--- a/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
@@ -59,7 +59,7 @@ class ScriptableDocument(fields: Seq[Field], currentValuesInDB: BSONDocument, co
   private val scriptableObjectId: Option[ScriptableObjectId] =
     objectIDOption.map(ScriptableObjectId(context, _))
 
-  @JSGetter
+  @JSGetter("_id")
   def getObjectId: ScriptableObjectId =
     scriptableObjectId.getOrElse(throw new NoSuchElementException("ObjectID does not exist"))
 

--- a/plugins/examples/db.js
+++ b/plugins/examples/db.js
@@ -35,7 +35,7 @@ exports.insert = function (key, value) {
         .onSuccess(function (doc) {
             console.info(
                 "New document{ _id: %s, key: %s, value: %s, time: %s } is inserted.",
-                doc.objectId.stringify, doc.key(), doc.value(), doc.time());
+                doc._id.stringify, doc.key(), doc.value(), doc.time());
         });
 };
 
@@ -137,7 +137,7 @@ exports.referenceInsert = function (key) {
     }).onFailure(function (message) {
         console.error("Cannot find data. ERROR: %s", message);
     }).map(function (data) {
-        console.log("ID: %s", data.objectId.stringify);
+        console.log("ID: %s", data._id.stringify);
         if (data) {
             return collection2.insert({ key: data.key(), value: data.value(), time: data.time(), ref: data }).onComplete(console.error);
         }


### PR DESCRIPTION
Currently, Collection and Document use objectId but Query uses _id for
object id.
This patch makes consist of their name.
