### PR TITLE
Throw an exception when readFile can't find the file.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFileSystem.scala
+++ b/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFileSystem.scala
@@ -59,7 +59,11 @@ object ScriptableFileSystem {
     implicit val encoding = Codec(options.getString("encoding").getOrElse(BeyondConfiguration.encoding))
 
     val readFuture = future {
-      val in = Resource.fromFile(fileName)
+      val file = new File(fileName)
+      if (!file.exists) {
+        throw new java.io.IOException("Can't find the file")
+      }
+      val in = Resource.fromFile(file)
       in.string
     }
     ScriptableFuture(context, readFuture)

--- a/plugins/test/fs.js
+++ b/plugins/test/fs.js
@@ -23,6 +23,17 @@ describe('file-system', function () {
         });
       });
     });
+
+    it.will('fire an exception when there is no file.', function (done) {
+      fs
+      .readFile('./plugins/test/assets/fs/nothing')
+      .onComplete(function (result, isSuccess) {
+        assert.async(done, function () {
+          assert.equal(isSuccess, false);
+          assert.equal(result, "Can't find the file");
+        });
+      });
+    });
   });
 
   describe('#writeFile()', function () {


### PR DESCRIPTION
Currently Resouce.fromFile doesn't throw an exception when there's no
file for the provided path. According to the scala-io document, it
should do. I fixed the problem with check the file existance and throw
an exception manually.
