### PR TITLE
Modify response.js to use ResponseInternal directly.

### DIFF
--- a/plugins/lib/response.js
+++ b/plugins/lib/response.js
@@ -59,11 +59,4 @@ exports.STATUS_CODES = {
   511 : 'Network Authentication Required' // RFC 6585
 };
 
-exports.Response = function (obj, contentType, statusCode) {
-    // FIXME: Extract this as a convenient method or use underscore.
-    var isString = Object.prototype.toString.call(obj) === '[object String]';
-    contentType = contentType || 'plain/text';
-    statusCode = statusCode || 200;
-    this._response = isString ? new ResponseInternal(obj, contentType, statusCode) : new ResponseInternal(JSON.stringify(obj), contentType, statusCode);
-};
-
+exports.Response = ResponseInternal;

--- a/plugins/test/response.js
+++ b/plugins/test/response.js
@@ -1,0 +1,54 @@
+var assert = require('assert');
+var Response = require("response").Response;
+require('bdd').mount(this);
+
+describe('Response', function () {
+  describe('#constructor()', function () {
+    it('should return a proper InternalResponse object.', function () {
+      var res = new Response('hello');
+      assert.equal(!!res, true);
+    });
+
+    it('should return an object with a JSON body.', function () {
+      var res = new Response({hello: 'world'});
+      assert.equal(!!res, true);
+    });
+
+    it('should return an object with a content type.', function () {
+      var res = new Response('hello', 'image/jpeg');
+      assert.equal(!!res, true);
+    });
+
+    it('should return an object with a content type and status code.', function () {
+      var res = new Response('hello', 'image/jpeg', 301);
+      assert.equal(!!res, true);
+    });
+  });
+
+  describe('#body', function () {
+    it('should return the body string of a Response obj.', function () {
+      var res = new Response('hello');
+      assert.equal(res.body, 'hello');
+    });
+
+    it('should return the stringified JSON body of a Response obj.', function () {
+      var body = {hello: 'world!'};
+      var res = new Response(body);
+      assert.equal(res.body, JSON.stringify(body));
+    });
+  });
+
+  describe('#contentType', function () {
+    it('should return the content type of a Response obj.', function () {
+      var res = new Response('hello', 'image/jpeg');
+      assert.equal(res.contentType, 'image/jpeg');
+    });
+  });
+
+  describe('#statusCode', function () {
+    it('should return the status code of a Response obj.', function () {
+      var res = new Response('hello', 'image/jpeg', 301);
+      assert.equal(res.statusCode, 301);
+    });
+  });
+});


### PR DESCRIPTION
The logic for the functionality was separated into a JavaScript and Scala files. In this case, if we wanted to change the logic, we would have to change both of them. This patch merged the logic in the JavaScript file into the Scala one.

Also a test case for ScriptableResponse has been added. Some properties have also been added to test the functionalities.

Basically, this fixes #159.
