### PR TITLE
Implement test server for plugin's http-client test.

### DIFF
--- a/plugins/test/assets/http-client/run-test-server.sh
+++ b/plugins/test/assets/http-client/run-test-server.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+mkfifo fifo || exit
+trap 'rm -f fifo' 0
+
+# Run server
+node plugins/test/assets/http-client/test-server.js > fifo &
+
+# Wait until reading 'listening'
+while read line; do
+  case $line in
+    listening) break;
+  esac
+done < fifo

--- a/plugins/test/assets/http-client/test-server.js
+++ b/plugins/test/assets/http-client/test-server.js
@@ -1,0 +1,110 @@
+/* global console, process */
+var Buffer = require('buffer').Buffer;
+var http = require('http');
+var qsparser = require('querystring').parse;
+var urlparser = require('url').parse;
+
+function notFound(res) {
+  res.writeHead(404);
+  res.end('Not found.');
+}
+
+var handlers = {};
+var server = http.createServer(function (req, res) {
+  var url = urlparser(req.url, true);
+
+  if (handlers[url.pathname]) {
+    handlers[url.pathname](url, req, res);
+  } else {
+    notFound(res);
+  }
+});
+
+handlers['/get'] = function (url, req, res) {
+  if (req.method === 'GET') {
+    res.end(JSON.stringify({
+      url: req.url,
+      headers: req.headers,
+      args: url.query
+    }));
+  } else {
+    notFound(res);
+  }
+};
+
+handlers['/post'] = handlers['/put'] = function (url, req, res) {
+  if (req.method === 'POST' || req.method === 'PUT') {
+    var data = '';
+
+    req.on('data', function (chunk) {
+      data += chunk.toString();
+    });
+
+    req.on('end', function () {
+      var form = null;
+
+      var contentType = req.headers['content-type'];
+      if (typeof contentType === 'string' &&
+          contentType.indexOf('application/x-www-form-urlencoded') >= 0) {
+        form = qsparser(data);
+      }
+
+      res.end(JSON.stringify({
+        url: req.url,
+        headers: req.headers,
+        form: form,
+        data: data
+      }));
+    });
+  } else {
+    notFound(res);
+  }
+};
+
+function authenticate(req) {
+  var auth = req.headers.authorization;
+  if (!auth) {
+    return null;
+  }
+
+  // malformed
+  var parts = auth.split(' ');
+  if ('basic' !== parts[0].toLowerCase() || !parts[1]) {
+    return null;
+  }
+  auth = parts[1];
+
+  // credentials
+  auth = new Buffer(auth, 'base64').toString();
+  auth = auth.match(/^([^:]*):(.*)$/);
+  if (!auth) {
+    return null;
+  }
+
+  return { id: auth[1], passwd: auth[2] };
+}
+
+handlers['/basic-auth'] = function (url, req, res) {
+  if (req.method === 'GET') {
+    var id = url.query.id;
+    var passwd = url.query.passwd;
+
+    var auth = authenticate(req);
+
+    res.end(JSON.stringify({
+      authenticated: (!!auth && auth.id === id && auth.passwd === passwd)
+    }));
+  } else {
+    notFound(res);
+  }
+};
+
+handlers['/quit'] = function (url, req, res) {
+  res.end();
+  server.close();
+  process.exit();
+};
+
+server.listen(1234, function () {
+  console.log('listening');
+});

--- a/plugins/test/http-client.js
+++ b/plugins/test/http-client.js
@@ -12,11 +12,23 @@ function complete(done, callback) {
   };
 }
 
+function exec(command) {
+  return java.lang.Runtime.getRuntime().exec(command);
+}
+
+before(function () {
+  exec('./plugins/test/assets/http-client/run-test-server.sh').waitFor();
+});
+
+after(function () {
+  exec('curl http://localhost:1234/quit');
+});
+
 describe('http-client', function () {
   describe('#get()', function () {
     var req;
     beforeEach(function () {
-      req = request.get('http://httpbin.org/get?hello=world');
+      req = request.get('http://localhost:1234/get?hello=world');
     });
 
     it.will('send a get request.', function (done) {
@@ -25,7 +37,7 @@ describe('http-client', function () {
         .onComplete(complete(done, function (res) {
           assert.async(done, function () {
             var result = JSON.parse(res.body);
-            assert.equal(result.url, 'http://httpbin.org/get?hello=world');
+            assert.equal(result.url, '/get?hello=world');
           });
         }));
     });
@@ -56,14 +68,14 @@ describe('http-client', function () {
 
     it.will('send a get request with headers.', function (done) {
       req
-        .set({'Hello': 'world', 'Beyond': 'framework', 'Number': 1234})
+        .set({'hello': 'world', 'beyond': 'framework', 'number': 1234})
         .end()
         .onComplete(complete(done, function (res) {
           assert.async(done, function () {
             var result = JSON.parse(res.body);
-            assert.equal(result.headers.Hello, 'world');
-            assert.equal(result.headers.Beyond, 'framework');
-            assert.equal(result.headers.Number, '1234');
+            assert.equal(result.headers.hello, 'world');
+            assert.equal(result.headers.beyond, 'framework');
+            assert.equal(result.headers.number, '1234');
           });
         }));
     });
@@ -72,7 +84,7 @@ describe('http-client', function () {
   describe('#post()', function () {
     var req;
     beforeEach(function () {
-      req = request.post('http://httpbin.org/post');
+      req = request.post('http://localhost:1234/post');
     });
 
     it.will('send a post request.', function (done) {
@@ -81,7 +93,7 @@ describe('http-client', function () {
         .onComplete(complete(done, function (res) {
           assert.async(done, function () {
             var result = JSON.parse(res.body);
-            assert.equal(result.url, 'http://httpbin.org/post');
+            assert.equal(result.url, '/post');
           });
         }));
     });
@@ -115,14 +127,14 @@ describe('http-client', function () {
 
     it.will('send a post request with headers.', function (done) {
       req
-        .set({'Hello': 'world', 'Beyond': 'framework', 'Number': 1234})
+        .set({'hello': 'world', 'beyond': 'framework', 'number': 1234})
         .end()
         .onComplete(complete(done, function (res) {
           assert.async(done, function () {
             var result = JSON.parse(res.body);
-            assert.equal(result.headers.Hello, 'world');
-            assert.equal(result.headers.Beyond, 'framework');
-            assert.equal(result.headers.Number, '1234');
+            assert.equal(result.headers.hello, 'world');
+            assert.equal(result.headers.beyond, 'framework');
+            assert.equal(result.headers.number, '1234');
           });
         }));
     });
@@ -131,7 +143,7 @@ describe('http-client', function () {
   describe('#put()', function () {
     var req;
     beforeEach(function () {
-      req = request.put('http://httpbin.org/put');
+      req = request.put('http://localhost:1234/put');
     });
 
     it.will('send a put request.', function (done) {
@@ -140,7 +152,7 @@ describe('http-client', function () {
         .onComplete(complete(done, function (res) {
           assert.async(done, function () {
             var result = JSON.parse(res.body);
-            assert.equal(result.url, 'http://httpbin.org/put');
+            assert.equal(result.url, '/put');
           });
         }));
     });
@@ -174,14 +186,14 @@ describe('http-client', function () {
 
     it.will('send a put request with headers.', function (done) {
       req
-        .set({'Hello': 'world', 'Beyond': 'framework', 'Number': 1234})
+        .set({'hello': 'world', 'beyond': 'framework', 'number': 1234})
         .end()
         .onComplete(complete(done, function (res) {
           assert.async(done, function () {
             var result = JSON.parse(res.body);
-            assert.equal(result.headers.Hello, 'world');
-            assert.equal(result.headers.Beyond, 'framework');
-            assert.equal(result.headers.Number, '1234');
+            assert.equal(result.headers.hello, 'world');
+            assert.equal(result.headers.beyond, 'framework');
+            assert.equal(result.headers.number, '1234');
           });
         }));
     });
@@ -190,7 +202,8 @@ describe('http-client', function () {
   describe('#auth()', function () {
     it.will('send a request with basic auth.', function (done) {
       request
-        .get('http://httpbin.org/basic-auth/hello/world')
+        .get('http://localhost:1234/basic-auth')
+        .query({'id': 'hello', 'passwd': 'world'})
         .auth('hello', 'world')
         .end()
         .onComplete(complete(done, function (res) {


### PR DESCRIPTION
Until now, httpbin.org has been used to test the http-client module. However, depending on a 3rd-party service makes the test unstable because the service could be shut down or internet connection could be cut off.

This commit implements a simple test server using Node.js's http module.
