### PR TITLE
Implement standalone mode for test.

### DIFF
--- a/conf/application.test.conf
+++ b/conf/application.test.conf
@@ -9,4 +9,5 @@ beyond {
   zookeeper {
     config-path = "conf/zoo.test.cfg"
   }
+  standalone-mode = true
 }

--- a/core/app/beyond/BeyondConfiguration.scala
+++ b/core/app/beyond/BeyondConfiguration.scala
@@ -57,4 +57,7 @@ object BeyondConfiguration {
 
     RouteAddress(hostAddress, port.toString)
   }
+
+  def isStandaloneMode: Boolean =
+    configuration.getBoolean("beyond.standalone-mode").getOrElse(false)
 }

--- a/core/app/beyond/BeyondSupervisor.scala
+++ b/core/app/beyond/BeyondSupervisor.scala
@@ -18,7 +18,9 @@ object BeyondSupervisor {
 class BeyondSupervisor extends Actor {
   context.actorOf(Props[LauncherSupervisor], LauncherSupervisor.Name)
   context.actorOf(Props[SystemMetricsSupervisor], SystemMetricsSupervisor.Name)
-  context.actorOf(Props[CuratorSupervisor], CuratorSupervisor.Name)
+  if (!BeyondConfiguration.isStandaloneMode) {
+    context.actorOf(Props[CuratorSupervisor], CuratorSupervisor.Name)
+  }
 
   override def receive: Receive = Map.empty
 }

--- a/core/app/beyond/launcher/LauncherSupervisor.scala
+++ b/core/app/beyond/launcher/LauncherSupervisor.scala
@@ -19,19 +19,21 @@ object LauncherSupervisor {
 class LauncherSupervisor extends Actor with ActorLogging {
   override def preStart() {
     def launchZooKeeperServerIfNecessary() {
-      import scala.collection.JavaConversions._
+      if (!BeyondConfiguration.isStandaloneMode) {
+        import scala.collection.JavaConversions._
 
-      val localAddresses = (for {
-        ni <- NetworkInterface.getNetworkInterfaces.toIterator
-        address <- ni.getInetAddresses
-      } yield address).toSet
-      log.info(s"Local addresses $localAddresses")
+        val localAddresses = (for {
+          ni <- NetworkInterface.getNetworkInterfaces.toIterator
+          address <- ni.getInetAddresses
+        } yield address).toSet
+        log.info(s"Local addresses $localAddresses")
 
-      val zooKeeperAddresses = BeyondConfiguration.zooKeeperServers.map(InetAddress.getByName)
-      log.info(s"ZooKeeper addresses $zooKeeperAddresses")
+        val zooKeeperAddresses = BeyondConfiguration.zooKeeperServers.map(InetAddress.getByName)
+        log.info(s"ZooKeeper addresses $zooKeeperAddresses")
 
-      if ((localAddresses & zooKeeperAddresses).nonEmpty) {
-        context.actorOf(Props[ZooKeeperLauncher], name = "zooKeeperLauncher")
+        if ((localAddresses & zooKeeperAddresses).nonEmpty) {
+          context.actorOf(Props[ZooKeeperLauncher], name = "zooKeeperLauncher")
+        }
       }
     }
 


### PR DESCRIPTION
There is no need to launch zookeepr for test. And restarting zookeeper
server for every test makes test slow.

This patch implements the option to launch standalone mode. The
standalone mode will not make routing table so it doesn't need to launch
zookeeper.
