### PR TITLE
Make metrics disablable.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -101,5 +101,8 @@ beyond {
   }
   pid-dir = "/tmp/beyond/"
   encoding = "UTF-8"
+
+# FIXME: Remove this feature after fixing the problem with sigar library.
+  enable-metrics = true
 }
 

--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -5,4 +5,6 @@ beyond {
   zookeeper {
     config-path = "conf/zoo.prod.cfg"
   }
+
+  enable-metrics = false
 }

--- a/core/app/beyond/BeyondConfiguration.scala
+++ b/core/app/beyond/BeyondConfiguration.scala
@@ -60,4 +60,7 @@ object BeyondConfiguration {
 
   def isStandaloneMode: Boolean =
     configuration.getBoolean("beyond.standalone-mode").getOrElse(false)
+
+  def enableMetrics: Boolean =
+    configuration.getBoolean("beyond.enable-metrics").getOrElse(true)
 }

--- a/core/app/beyond/BeyondMBean.scala
+++ b/core/app/beyond/BeyondMBean.scala
@@ -9,15 +9,20 @@ import org.hyperic.sigar.jmx.SigarRegistry
 object BeyondMBean {
   private case class MBeanRegistry(mbean: AnyRef, name: ObjectName)
   private val mbeans = {
-    val sigarRegistry = {
-      val sigarMBean = new SigarRegistry
-      MBeanRegistry(sigarMBean, new ObjectName(sigarMBean.getObjectName))
+    val sigarRegistry = if (BeyondConfiguration.enableMetrics) {
+      val sigarRegistry = {
+        val sigarMBean = new SigarRegistry
+        MBeanRegistry(sigarMBean, new ObjectName(sigarMBean.getObjectName))
+      }
+      Some(sigarRegistry)
+    } else {
+      None
     }
     val numberOfRequestsPerSecondRegistry = {
       val numberOfRequestsPerSecondMBean = new NumberOfRequestsPerSecond
       MBeanRegistry(numberOfRequestsPerSecondMBean, NumberOfRequestsPerSecond.objectName)
     }
-    Seq(sigarRegistry, numberOfRequestsPerSecondRegistry)
+    sigarRegistry ++: Some(numberOfRequestsPerSecondRegistry)
   }
 
   def register() {

--- a/core/app/beyond/BeyondSupervisor.scala
+++ b/core/app/beyond/BeyondSupervisor.scala
@@ -17,7 +17,11 @@ object BeyondSupervisor {
 
 class BeyondSupervisor extends Actor {
   context.actorOf(Props[LauncherSupervisor], LauncherSupervisor.Name)
-  context.actorOf(Props[SystemMetricsSupervisor], SystemMetricsSupervisor.Name)
+
+  if (BeyondConfiguration.enableMetrics) {
+    context.actorOf(Props[SystemMetricsSupervisor], SystemMetricsSupervisor.Name)
+  }
+
   if (!BeyondConfiguration.isStandaloneMode) {
     context.actorOf(Props[CuratorSupervisor], CuratorSupervisor.Name)
   }

--- a/core/app/beyond/metrics/RequestsCountFilter.scala
+++ b/core/app/beyond/metrics/RequestsCountFilter.scala
@@ -1,6 +1,7 @@
 package beyond.metrics
 
 import akka.actor.Props
+import beyond.BeyondConfiguration
 import play.api.libs.concurrent.Akka
 import play.api.mvc._
 import scala.concurrent.Future
@@ -9,7 +10,11 @@ object RequestsCountFilter extends Filter {
   // This has to be lazy, because Filter is initialized before application has been started.
   private lazy val requestsCounter = {
     import play.api.Play.current
-    Akka.system.actorOf(Props[RequestsCounter], name = RequestsCounter.Name)
+    if (BeyondConfiguration.enableMetrics) {
+      Akka.system.actorOf(Props[RequestsCounter], name = RequestsCounter.Name)
+    } else {
+      Akka.system.deadLetters
+    }
   }
   def apply(next: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     requestsCounter ! RequestsCounter.Increase


### PR DESCRIPTION
Beyond uses sigar for metrics, but there is a problem to use sigar
library in production mode. So disable it until fix the problem.
