### PR TITLE
Implement static file serving for plugin.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFile.scala
+++ b/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFile.scala
@@ -30,20 +30,20 @@ object ScriptableFile {
   }
 }
 
-class ScriptableFile(file: File) extends ScriptableObject {
+class ScriptableFile(val internal: File) extends ScriptableObject {
   def this() = this(null)
 
   override def getClassName: String = "File"
 
   @JSGetter
-  def getName: String = file.getName
+  def getName: String = internal.getName
 
   @JSGetter
-  def getPath: String = file.getPath
+  def getPath: String = internal.getPath
 
   @JSGetter
-  def getIsFile: Boolean = file.isFile
+  def getIsFile: Boolean = internal.isFile
 
   @JSGetter
-  def getIsDirectory: Boolean = file.isDirectory
+  def getIsDirectory: Boolean = internal.isDirectory
 }

--- a/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFileSystem.scala
+++ b/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFileSystem.scala
@@ -49,6 +49,10 @@ object ScriptableFileSystem {
   }
 
   @JSStaticFunctionAnnotation
+  def read(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFile =
+    ScriptableFile(context, new File(args(0).asInstanceOf[String]))
+
+  @JSStaticFunctionAnnotation
   def readFile(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
     implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
 

--- a/plugins/main.js
+++ b/plugins/main.js
@@ -158,6 +158,10 @@ exports.handle = function (req) {
             return new Response(crypto.test());
         case "buffer":
             return new Response(buffer.test());
+        case "static":
+            var staticPath = './plugins/test/assets/fs/';
+            fileName = decodeURIComponent(tokens[0]);
+            return new Response(fs.read(staticPath + fileName));
         default:
             break;
     }

--- a/plugins/test/fs.js
+++ b/plugins/test/fs.js
@@ -162,4 +162,27 @@ describe('file-system', function () {
       });
     });
   });
+
+  describe('#read()', function () {
+    it('returns a file object.', function () {
+      var file = fs.read('./plugins/test/assets/fs/hello');
+      assert.equal(typeof file, 'object');
+    });
+
+    it('returns an object containing its information.', function () {
+      var file = fs.read('./plugins/test/assets/fs/hello');
+      assert.equal(file.name, 'hello');
+      assert.equal(file.path, './plugins/test/assets/fs/hello');
+      assert.equal(file.isFile, true);
+      assert.equal(file.isDirectory, false);
+    });
+
+    it('returns an object representing a directory.', function () {
+      var file = fs.read('./plugins/test/assets/fs/dir');
+      assert.equal(file.name, 'dir');
+      assert.equal(file.path, './plugins/test/assets/fs/dir');
+      assert.equal(file.isFile, false);
+      assert.equal(file.isDirectory, true);
+    });
+  });
 });


### PR DESCRIPTION
Now Response accepts a File object to serve the file as a static file. File system module's `read` method will return a File object and we can pass the object to the Response constructor.

The basic usage is described as code in `main.js`, and a test case for it has also been added.
