### PR TITLE
Add argv for sharding and stuff

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,6 +93,9 @@ beyond {
       max-sleep = "1000ms"
     }
   }
+  mongodb {
+    type = "standalone"
+  }
   plugin {
     path = ["plugins"]
   }

--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -1,6 +1,12 @@
+# Reactive Mongo
+# FIXME: Should be mongos servers
+mongodb.servers = ["localhost:27017"]
+
 beyond {
   mongodb {
     dbpath = "data/prod/mongo"
+    # Other instance types could be set with `--Dbeyond.mongodb.type`.
+    type = "standalone" # FIXME: should be "routing"
   }
   zookeeper {
     config-path = "conf/zoo.prod.cfg"

--- a/core/app/beyond/BeyondConfiguration.scala
+++ b/core/app/beyond/BeyondConfiguration.scala
@@ -1,5 +1,6 @@
 package beyond
 
+import beyond.launcher.mongodb.MongoDBInstanceType
 import beyond.route.RouteAddress
 import java.io.File
 import org.apache.curator.RetryPolicy
@@ -63,4 +64,15 @@ object BeyondConfiguration {
 
   def enableMetrics: Boolean =
     configuration.getBoolean("beyond.enable-metrics").getOrElse(true)
+
+  lazy val mongodbType: MongoDBInstanceType.Value =
+    configuration.getString("beyond.mongodb.type")
+      .map {
+        case "standalone" => MongoDBInstanceType.Standalone
+        case "config" => MongoDBInstanceType.Config
+        case "routing" => MongoDBInstanceType.Routing
+        case "shard" => MongoDBInstanceType.Shard
+        case _ => throw new IllegalArgumentException("wrong.mongodb.type")
+      }
+      .getOrElse(MongoDBInstanceType.default)
 }

--- a/core/app/beyond/launcher/mongodb/MongoDBInstanceType.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBInstanceType.scala
@@ -1,0 +1,6 @@
+package beyond.launcher.mongodb
+
+object MongoDBInstanceType extends Enumeration {
+  val Standalone, Config, Routing, Shard = Value
+  val default = Standalone
+}

--- a/core/app/beyond/launcher/mongodb/MongoDBLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBLauncher.scala
@@ -1,0 +1,110 @@
+package beyond.launcher.mongodb
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import beyond.BeyondConfiguration
+import beyond.MongoMixin
+import beyond.TickGenerator
+import java.io.IOException
+import play.api.libs.concurrent.Akka
+import reactivemongo.core.commands.Status
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.sys.process._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scalax.file.Path
+
+object MongoDBLauncher {
+  val ServerNotRespondingTimeout = 30.seconds
+  val RetryDelay = 5.seconds
+
+  val RetryDelayAtInitialization = 3.seconds
+}
+
+abstract class MongoDBLauncher extends {
+  override protected val initialDelay = 10.seconds
+  override protected val tickInterval = 1.second
+} with Actor with TickGenerator with ActorLogging with MongoMixin {
+  import beyond.launcher._
+  import MongoDBLauncher._
+
+  protected val launcherName: String
+  protected val pidFileName: String
+
+  protected val pidFilePath: Path = Path.fromString(BeyondConfiguration.pidDirectory) / pidFileName
+
+  private def mongoBinPath(bin: String): Option[String] = try {
+    Some((s"which $bin" !!).trim) // Locate Unix mongod path
+  } catch {
+    case _: IOException => try {
+      Some((s"where.exe $bin.exe" !!).trim) // Locate Windows mongod path
+    } catch {
+      case _: IOException => None
+    }
+  }
+
+  protected def mongodPath: Option[String] = mongoBinPath("mongod")
+  protected def mongosPath: Option[String] = mongoBinPath("mongos")
+  protected def mongoPath: Option[String] = mongoBinPath("mongo")
+
+  override def preRestart(reason: Throwable, message: Option[Any]) {
+    super.preRestart(reason, message)
+    terminateProcessIfExists(pidFilePath)
+  }
+
+  protected val shouldCheckHealth: Boolean = true
+  private def healthCheck(delay: FiniteDuration) {
+    if (shouldCheckHealth) {
+      import play.api.Play.current
+      implicit val ec: ExecutionContext = Akka.system.dispatcher
+      context.system.scheduler.scheduleOnce(delay) {
+        db.command(Status).onComplete {
+          case mongoServerStatus: Try[_] =>
+            self ! mongoServerStatus
+        }
+      }
+    }
+  }
+
+  protected def launchProcess(): Unit
+
+  override def preStart() {
+    log.info(launcherName + " started")
+    launchProcess()
+    healthCheck(RetryDelayAtInitialization)
+  }
+
+  override def postStop() {
+    super.postStop()
+    terminateProcessIfExists(pidFilePath)
+    log.info(launcherName + " stopped")
+  }
+
+  override def receive: Receive = initializing
+
+  private def initializing: Receive = {
+    case Success(_) =>
+      healthCheck(RetryDelay)
+      context.become(initialized(ServerNotRespondingTimeout))
+    case Failure(_) =>
+      throw new ServerNotRespondingException
+    case TickGenerator.Tick => // Ignore Tick on initializing.
+  }
+
+  private def initialized(timeout: FiniteDuration): Receive = {
+    case Success(_) =>
+      healthCheck(RetryDelay)
+      context.become(initialized(ServerNotRespondingTimeout))
+    case Failure(_) =>
+      healthCheck(RetryDelay)
+    case TickGenerator.Tick =>
+      val newTimeout = timeout - tickInterval
+      if (newTimeout > Duration.Zero) {
+        context.become(initialized(newTimeout))
+      } else {
+        throw new ServerNotRespondingException
+      }
+  }
+}

--- a/core/app/beyond/launcher/mongodb/MongoDBStandaloneLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBStandaloneLauncher.scala
@@ -1,69 +1,16 @@
 package beyond.launcher.mongodb
 
-import akka.actor.Actor
-import akka.actor.ActorLogging
 import beyond.BeyondConfiguration
-import beyond.MongoMixin
-import beyond.TickGenerator
 import java.io.File
-import java.io.IOException
-import play.api.libs.concurrent.Akka
-import reactivemongo.core.commands.Status
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 import scala.sys.process._
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import scalax.file.Path
 
-object MongoDBStandaloneLauncher {
-  val ServerNotRespondingTimeout = 30.seconds
-  val RetryDelay = 5.seconds
-
-  val RetryDelayAtInitialization = 3.seconds
-}
-
-// FIXME: Extract ProcessLauncher trait from MongoDBStandaloneLauncher and reuse it
-// once we have more than one process launchers.
-class MongoDBStandaloneLauncher extends {
-  override protected val initialDelay = 10.seconds
-  override protected val tickInterval = 1.second
-} with Actor with TickGenerator with ActorLogging with MongoMixin {
+class MongoDBStandaloneLauncher extends MongoDBLauncher {
   import beyond.launcher._
 
-  private val pidFilePath: Path = Path.fromString(BeyondConfiguration.pidDirectory) / "mongo.pid"
+  override protected val launcherName: String = "MongoDBStandaloneLauncher"
+  override protected val pidFileName: String = "mongo-standalone.pid"
 
-  private def mongodPath: Option[String] = try {
-    Some(("which mongod" !!).trim) // Locate Unix mongod path
-  } catch {
-    case _: IOException => try {
-      Some(("where.exe mongod.exe" !!).trim) // Locate Windows mongod path
-    } catch {
-      case _: IOException => None
-    }
-  }
-
-  override def preRestart(reason: Throwable, message: Option[Any]) {
-    super.preRestart(reason, message)
-    terminateProcessIfExists(pidFilePath)
-  }
-
-  import MongoDBStandaloneLauncher._
-
-  private def healthCheck(delay: FiniteDuration) {
-    import play.api.Play.current
-    implicit val ec: ExecutionContext = Akka.system.dispatcher
-    context.system.scheduler.scheduleOnce(delay) {
-      db.command(Status).onComplete {
-        case mongoServerStatus: Try[_] =>
-          self ! mongoServerStatus
-      }
-    }
-  }
-
-  override def preStart() {
-    log.info("MongoDBStandaloneLauncher started")
+  override protected def launchProcess() {
     val dbPath = new File(BeyondConfiguration.mongoDBPath)
     if (!dbPath.exists()) {
       dbPath.mkdirs()
@@ -76,39 +23,5 @@ class MongoDBStandaloneLauncher extends {
     val processBuilder = Process(Seq(path, "--dbpath", dbPath.getCanonicalPath, "--pidfilepath", pidFilePath.path))
     processBuilder.run()
     log.info("MongoDB started")
-
-    healthCheck(RetryDelayAtInitialization)
-  }
-
-  override def postStop() {
-    super.postStop()
-    terminateProcessIfExists(pidFilePath)
-    log.info("MongoDBStandaloneLauncher stopped")
-  }
-
-  override def receive: Receive = initializing
-
-  private def initializing: Receive = {
-    case Success(_) =>
-      healthCheck(RetryDelay)
-      context.become(initialized(ServerNotRespondingTimeout))
-    case Failure(_) =>
-      throw new ServerNotRespondingException
-    case TickGenerator.Tick => // Ignore Tick on initializing.
-  }
-
-  private def initialized(timeout: FiniteDuration): Receive = {
-    case Success(_) =>
-      healthCheck(RetryDelay)
-      context.become(initialized(ServerNotRespondingTimeout))
-    case Failure(_) =>
-      healthCheck(RetryDelay)
-    case TickGenerator.Tick =>
-      val newTimeout = timeout - tickInterval
-      if (newTimeout > Duration.Zero) {
-        context.become(initialized(newTimeout))
-      } else {
-        throw new ServerNotRespondingException
-      }
   }
 }


### PR DESCRIPTION
Concerning #167.

The first patch is to add `use-sharding` option for MongoDB. Sharding itself hasn't been added yet.

The other is to separate a common part of `MongoDBStandaloneLauncher` into `MongoDBLauncher`, as it can be used in another MongoDB instance launchers.

@sgkim126 @murmur76 @kimchoco, please review this.