### PR TITLE
Handle ConsString for JSON body in ScriptableHttpClient.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/http/ScriptableHttpClient.scala
+++ b/core/app/beyond/engine/javascript/lib/http/ScriptableHttpClient.scala
@@ -5,6 +5,7 @@ import beyond.engine.javascript.JSArray
 import beyond.engine.javascript.JSFunction
 import beyond.engine.javascript.lib.ScriptableFuture
 import com.beyondframework.rhino.ContextOps._
+import org.mozilla.javascript.ConsString
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.ScriptRuntime
 import org.mozilla.javascript.Scriptable
@@ -84,6 +85,8 @@ object ScriptableHttpClient {
             key -> JsNumber(BigDecimal(number))
           case string: String =>
             key -> JsString(string)
+          case consString: ConsString =>
+            key -> JsString(consString.toString)
           case obj: Scriptable =>
             key -> convertScriptableToJsObject(obj)
         }


### PR DESCRIPTION
Currently a convert function in ScriptableHttpClient doesn't handle the ConsString object. This patch fixes the module to handle it.
