### PR TITLE
Support the array of optional value.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableDocument.scala
@@ -102,7 +102,7 @@ class ScriptableDocument(fields: Seq[Field], currentValuesInDB: BSONDocument, co
   private def fieldByName(name: String): Field = fields.find(_.name == name).get
 
   private def currentJavaScriptValue(name: String)(implicit context: Context, scope: Scriptable): AnyRef = {
-    val scalaValue = currentBSONValue(name).map(AnyRefBSONHandler.read).getOrElse(fieldByName(name).defaultValue.getOrElse(Unit))
+    val scalaValue = currentBSONValue(name).map(AnyRefBSONHandler.read).getOrElse(fieldByName(name).defaultValue.orNull)
     convertScalaToJavaScript(scalaValue)(context, scope)
   }
 

--- a/core/app/beyond/engine/javascript/lib/database/package.scala
+++ b/core/app/beyond/engine/javascript/lib/database/package.scala
@@ -1,16 +1,16 @@
 package beyond.engine.javascript.lib
 
-import java.util.Date
-import java.{ lang => jl }
 import beyond.engine.javascript.JSArray
 import com.beyondframework.rhino.ContextOps._
+import java.util.Date
+import java.{ lang => jl }
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.Function
 import org.mozilla.javascript.NativeArray
 import org.mozilla.javascript.NativeJavaObject
 import org.mozilla.javascript.ScriptRuntime
-import org.mozilla.javascript.ScriptableObject
 import org.mozilla.javascript.Scriptable
+import org.mozilla.javascript.ScriptableObject
 import org.mozilla.javascript.Undefined
 import reactivemongo.bson.BSONArray
 import reactivemongo.bson.BSONBoolean

--- a/core/app/beyond/engine/javascript/lib/database/package.scala
+++ b/core/app/beyond/engine/javascript/lib/database/package.scala
@@ -11,7 +11,6 @@ import org.mozilla.javascript.NativeJavaObject
 import org.mozilla.javascript.ScriptRuntime
 import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
-import org.mozilla.javascript.Undefined
 import reactivemongo.bson.BSONArray
 import reactivemongo.bson.BSONBoolean
 import reactivemongo.bson.BSONDateTime
@@ -21,9 +20,9 @@ import reactivemongo.bson.BSONHandler
 import reactivemongo.bson.BSONInteger
 import reactivemongo.bson.BSONJavaScript
 import reactivemongo.bson.BSONLong
+import reactivemongo.bson.BSONNull
 import reactivemongo.bson.BSONObjectID
 import reactivemongo.bson.BSONString
-import reactivemongo.bson.BSONUndefined
 import reactivemongo.bson.BSONValue
 
 package object database {
@@ -44,11 +43,12 @@ package object database {
         })
       case seq: Seq[AnyRef] =>
         BSONArray(seq.map(write))
-      case _: Undefined => BSONUndefined
       case ObjectId(id) =>
         id
       case native: NativeJavaObject =>
         write(native.unwrap())
+      case null =>
+        BSONNull
       case _ =>
         throw new IllegalArgumentException(s"$value(${value.getClass} cannot be a BSONValue")
     }
@@ -68,8 +68,9 @@ package object database {
         }.toMap
       case array: BSONArray =>
         array.values.map(read)
-      case BSONUndefined => Undefined.instance
       case id: BSONObjectID => ObjectId(id)
+      case BSONNull =>
+        null
       case _ =>
         throw new IllegalArgumentException(s"$bson cannot be a scala object")
     }
@@ -178,8 +179,8 @@ package object database {
       context.newObject(scope, "Array", args)
     case objectID: ObjectId =>
       context.newObject(scope, "ObjectId", objectID.toString)
-    case Unit =>
-      Undefined.instance
+    case null =>
+      null
     case _ =>
       throw new IllegalArgumentException(s"$value(${value.getClass} cannot be a JavaScript Object")
   }


### PR DESCRIPTION
Currently, we don't put the value for optional, but there is need to save something for the value of array. (e.g. `type: 'array', elementType: { type: 'int', optional: true }`)

We determined to put null for optional value.
And this patch also changes the option name to nullable, because optional can be mistaken. But keeping optional option for a while to support backward compatibility.