### PR TITLE
Change pidFilePath in MongoDBLauncher into lazy val.

### DIFF
--- a/core/app/beyond/launcher/mongodb/MongoDBLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBLauncher.scala
@@ -33,7 +33,7 @@ abstract class MongoDBLauncher extends {
   protected val launcherName: String
   protected val pidFileName: String
 
-  protected val pidFilePath: Path = Path.fromString(BeyondConfiguration.pidDirectory) / pidFileName
+  protected lazy val pidFilePath: Path = Path.fromString(BeyondConfiguration.pidDirectory) / pidFileName
 
   private def mongoBinPath(bin: String): Option[String] = try {
     Some((s"which $bin" !!).trim) // Locate Unix mongod path


### PR DESCRIPTION
If the variable is initialized in the constructor of MongoDBLauncher abstraction class, an error will occur because an abstract variable, pidFileName, has not yet been initialized. So I changed it to lazy val to defer the initialization.

This patch fixes the following Travis CI failure.

[SollmoStudio/northstarserver#125](https://magnum.travis-ci.com/SollmoStudio/northstarserver/builds/8499702)