### PR TITLE
Add a 'wait' helper for plugin tests.

### DIFF
--- a/core/app/beyond/plugin/test/BeyondTestGlobal.scala
+++ b/core/app/beyond/plugin/test/BeyondTestGlobal.scala
@@ -8,6 +8,7 @@ import org.mozilla.javascript.commonjs.module.provider.ModuleSourceProvider
 class BeyondTestGlobal(libraryProvider: ModuleSourceProvider) extends BeyondGlobal(libraryProvider) {
   override def init(cx: Context) {
     super.init(cx)
+    ScriptableObject.defineClass(this, classOf[TestHelper])
     ScriptableObject.defineClass(this, classOf[TestReporter])
   }
 }

--- a/core/app/beyond/plugin/test/TestHelper.scala
+++ b/core/app/beyond/plugin/test/TestHelper.scala
@@ -1,0 +1,17 @@
+package beyond.plugin.test
+
+import beyond.engine.javascript.lib.ScriptableFuture
+import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.annotations.JSStaticFunction
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object TestHelper {
+  @JSStaticFunction("wait")
+  def jsWait(scriptableFuture: ScriptableFuture): AnyRef =
+    Await.result(scriptableFuture.future, 60.second)
+}
+
+class TestHelper extends ScriptableObject {
+  override def getClassName: String = "TestHelper"
+}

--- a/plugins/test/fs.js
+++ b/plugins/test/fs.js
@@ -1,38 +1,27 @@
 var assert = require('assert');
 var fs = require('fs');
+var wait = require('test-helper').wait;
 require('bdd').mount(this);
 
 describe('file-system', function () {
   describe('#readFile()', function () {
-    it.will('return the data of the file.', function (done) {
-      fs
-      .readFile('./plugins/test/assets/fs/beyond')
-      .onComplete(function (data) {
-        assert.async(done, function () {
-          assert.equal(data, 'Beyond framework\n');
-        });
-      });
+    it('return the data of the file.', function () {
+      var data = wait(fs.readFile('./plugins/test/assets/fs/beyond'));
+      assert.equal(data, 'Beyond framework\n');
     });
 
-    it.will('return the data of the file with a specific encoding.', function (done) {
-      fs
-      .readFile('./plugins/test/assets/fs/hello', {encoding: 'EUC-KR'})
-      .onComplete(function (data) {
-        assert.async(done, function () {
-          assert.equal(data, '안녕, 세계!\n');
-        });
-      });
+    it('return the data of the file with a specific encoding.', function () {
+      var data = wait(fs.readFile('./plugins/test/assets/fs/hello', {encoding: 'EUC-KR'}));
+      assert.equal(data, '안녕, 세계!\n');
     });
 
-    it.will('fire an exception when there is no file.', function (done) {
-      fs
-      .readFile('./plugins/test/assets/fs/nothing')
-      .onComplete(function (result, isSuccess) {
-        assert.async(done, function () {
-          assert.equal(isSuccess, false);
-          assert.equal(result, "Can't find the file");
-        });
-      });
+    it('fire an exception when there is no file.', function () {
+      try {
+        wait(fs.readFile('./plugins/test/assets/fs/nothing'));
+        throw new Error('no error!');
+      } catch (e) {
+        assert.equal(e.message, "java.io.IOException: Can't find the file");
+      }
     });
   });
 
@@ -50,7 +39,7 @@ describe('file-system', function () {
     beforeEach(removeTestFile);
     afterEach(removeTestFile);
 
-    function contentEqualTo(expected, done, options) {
+    function contentEqualTo(expected, options) {
       var future;
       if (typeof options === 'undefined') {
         future = fs.readFile(testFilePath);
@@ -58,57 +47,34 @@ describe('file-system', function () {
         future = fs.readFile(testFilePath, options);
       }
 
-      future
-      .onComplete(function (data) {
-        assert.async(done, function () {
-          assert.equal(data, expected);
-        });
-      });
+      var data = wait(future);
+      assert.equal(data, expected);
     }
 
-    function permissionEqualTo(expected, done) {
-      assert.async(done, function () {
-        var error = !!exec(["sh", "-c", "find " + testFilePath + " -perm " + expected + " | grep '.*'"]);
-        assert.equal(error, false);
-      });
+    function permissionEqualTo(expected) {
+      var error = !!exec(["sh", "-c", "find " + testFilePath + " -perm " + expected + " | grep '.*'"]);
+      assert.equal(error, false);
     }
 
-    it.will('write data to a file.', function (done) {
-      fs
-      .writeFile(testFilePath, "Hello, world!")
-      .onComplete(function () {
-        contentEqualTo("Hello, world!", done);
-      });
+    it('write data to a file.', function () {
+      wait(fs.writeFile(testFilePath, "Hello, world!"));
+      contentEqualTo("Hello, world!");
     });
 
-    it.will('write data to a file with encoding.', function (done) {
-      fs
-      .writeFile(testFilePath, "안녕, 세계!", {encoding: 'EUC-KR'})
-      .onComplete(function () {
-        contentEqualTo("안녕, 세계!", done, {encoding: 'EUC-KR'});
-      });
+    it('write data to a file with encoding.', function () {
+      wait(fs.writeFile(testFilePath, "안녕, 세계!", {encoding: 'EUC-KR'}));
+      contentEqualTo("안녕, 세계!", {encoding: 'EUC-KR'});
     });
 
-    it.will('write data to a file with mode.', function (done) {
-      fs
-      .writeFile(testFilePath, "Hello, world!", {mode: 0765})
-      .onComplete(function () {
-        permissionEqualTo('765', done);
-      });
+    it('write data to a file with mode.', function () {
+      wait(fs.writeFile(testFilePath, "Hello, world!", {mode: 0765}));
+      permissionEqualTo('765');
     });
 
-    it.will('write data to a file with encoding and mode.', function (done) {
-      fs
-      .writeFile(testFilePath, "안녕, 세계!", {encoding: 'EUC-KR', mode: 0657})
-      .onComplete(function () {
-        permissionEqualTo('657', function (err) {
-          if (err) {
-            done(err);
-          } else {
-            contentEqualTo("안녕, 세계!", done, {encoding: 'EUC-KR'});
-          }
-        });
-      });
+    it('write data to a file with encoding and mode.', function () {
+      wait(fs.writeFile(testFilePath, "안녕, 세계!", {encoding: 'EUC-KR', mode: 0657}));
+      permissionEqualTo('657');
+      contentEqualTo("안녕, 세계!", {encoding: 'EUC-KR'});
     });
   });
 
@@ -124,42 +90,30 @@ describe('file-system', function () {
       })[0];
     }
 
-    it.will('return the list of files with the correct length.', function (done) {
-      future
-      .onComplete(function (files) {
-        assert.async(done, function () {
-          assert.equal(files.length, 3);
-        });
-      });
+    it('return the list of files with the correct length.', function () {
+      var files = wait(future);
+      assert.equal(files.length, 3);
     });
 
-    it.will('return the list of files containing static files', function (done) {
-      future
-      .onComplete(function (files) {
-        assert.async(done, function () {
-          assert.equal(findWithName(files, 'hello').name, 'hello');
-          assert.equal(findWithName(files, 'hello').path, './plugins/test/assets/fs/hello');
-          assert.equal(findWithName(files, 'hello').isFile, true);
-          assert.equal(findWithName(files, 'hello').isDirectory, false);
+    it('return the list of files containing static files', function () {
+      var files = wait(future);
+      assert.equal(findWithName(files, 'hello').name, 'hello');
+      assert.equal(findWithName(files, 'hello').path, './plugins/test/assets/fs/hello');
+      assert.equal(findWithName(files, 'hello').isFile, true);
+      assert.equal(findWithName(files, 'hello').isDirectory, false);
 
-          assert.equal(findWithName(files, 'beyond').name, 'beyond');
-          assert.equal(findWithName(files, 'beyond').path, './plugins/test/assets/fs/beyond');
-          assert.equal(findWithName(files, 'beyond').isFile, true);
-          assert.equal(findWithName(files, 'beyond').isDirectory, false);
-        });
-      });
+      assert.equal(findWithName(files, 'beyond').name, 'beyond');
+      assert.equal(findWithName(files, 'beyond').path, './plugins/test/assets/fs/beyond');
+      assert.equal(findWithName(files, 'beyond').isFile, true);
+      assert.equal(findWithName(files, 'beyond').isDirectory, false);
     });
 
-    it.will('return the list of files containing the directory', function (done) {
-      future
-      .onComplete(function (files) {
-        assert.async(done, function () {
-          assert.equal(findWithName(files, 'dir').name, 'dir');
-          assert.equal(findWithName(files, 'dir').path, './plugins/test/assets/fs/dir');
-          assert.equal(findWithName(files, 'dir').isFile, false);
-          assert.equal(findWithName(files, 'dir').isDirectory, true);
-        });
-      });
+    it('return the list of files containing the directory', function () {
+      var files = wait(future);
+      assert.equal(findWithName(files, 'dir').name, 'dir');
+      assert.equal(findWithName(files, 'dir').path, './plugins/test/assets/fs/dir');
+      assert.equal(findWithName(files, 'dir').isFile, false);
+      assert.equal(findWithName(files, 'dir').isDirectory, true);
     });
   });
 

--- a/plugins/test/http-client.js
+++ b/plugins/test/http-client.js
@@ -1,16 +1,7 @@
 var assert = require('assert');
 var request = require('http-client');
+var wait = require('test-helper').wait;
 require('bdd').mount(this);
-
-function complete(done, callback) {
-  return function (res, success) {
-    if (success) {
-      callback(res);
-    } else {
-      done('failed.');
-    }
-  };
-}
 
 function exec(command) {
   return java.lang.Runtime.getRuntime().exec(command);
@@ -31,53 +22,33 @@ describe('http-client', function () {
       req = request.get('http://localhost:1234/get?hello=world');
     });
 
-    it.will('send a get request.', function (done) {
-      req
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.url, '/get?hello=world');
-          });
-        }));
+    it('send a get request.', function () {
+      var res = wait(req.end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.url, '/get?hello=world');
     });
 
-    it.will('send a get request with query string in url.', function (done) {
-      req
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.args.hello, 'world');
-          });
-        }));
+    it('send a get request with query string in url.', function () {
+      var res = wait(req.end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.args.hello, 'world');
     });
 
-    it.will('send a get request with query string with query().', function (done) {
-      req
-        .query({'query': 'string'})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.args.hello, 'world');
-            assert.equal(result.args.query, 'string');
-          });
-        }));
+    it('send a get request with query string with query().', function () {
+      var res = wait(req.query({'query': 'string'}).end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.args.hello, 'world');
+      assert.equal(result.args.query, 'string');
     });
 
-    it.will('send a get request with headers.', function (done) {
-      req
+    it('send a get request with headers.', function () {
+      var res = wait(req
         .set({'hello': 'world', 'beyond': 'framework', 'number': 1234})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.headers.hello, 'world');
-            assert.equal(result.headers.beyond, 'framework');
-            assert.equal(result.headers.number, '1234');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.headers.hello, 'world');
+      assert.equal(result.headers.beyond, 'framework');
+      assert.equal(result.headers.number, '1234');
     });
   });
 
@@ -87,56 +58,39 @@ describe('http-client', function () {
       req = request.post('http://localhost:1234/post');
     });
 
-    it.will('send a post request.', function (done) {
-      req
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.url, '/post');
-          });
-        }));
+    it('send a post request.', function () {
+      var res = wait(req.end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.url, '/post');
     });
 
-    it.will('send a post request with form data.', function (done) {
-      req
+    it('send a post request with form data.', function () {
+      var res = wait(req
         .send({'hello': 'world', 'beyond': 'framework'})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.form.hello, 'world');
-            assert.equal(result.form.beyond, 'framework');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.form.hello, 'world');
+      assert.equal(result.form.beyond, 'framework');
     });
 
-    it.will('send a post request with JSON data.', function (done) {
-      req
+    it('send a post request with JSON data.', function () {
+      var res = wait(req
         .json({'hello': 'world', 'beyond': 'framework'})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            var jsonData = JSON.parse(result.data);
-            assert.equal(jsonData.hello, 'world');
-            assert.equal(jsonData.beyond, 'framework');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      var jsonData = JSON.parse(result.data);
+      assert.equal(jsonData.hello, 'world');
+      assert.equal(jsonData.beyond, 'framework');
     });
 
-    it.will('send a post request with headers.', function (done) {
-      req
+    it('send a post request with headers.', function () {
+      var res = wait(req
         .set({'hello': 'world', 'beyond': 'framework', 'number': 1234})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.headers.hello, 'world');
-            assert.equal(result.headers.beyond, 'framework');
-            assert.equal(result.headers.number, '1234');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.headers.hello, 'world');
+      assert.equal(result.headers.beyond, 'framework');
+      assert.equal(result.headers.number, '1234');
     });
   });
 
@@ -146,72 +100,51 @@ describe('http-client', function () {
       req = request.put('http://localhost:1234/put');
     });
 
-    it.will('send a put request.', function (done) {
-      req
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.url, '/put');
-          });
-        }));
+    it('send a put request.', function () {
+      var res = wait(req.end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.url, '/put');
     });
 
-    it.will('send a put request with form data.', function (done) {
-      req
+    it('send a put request with form data.', function () {
+      var res = wait(req
         .send({'hello': 'world', 'beyond': 'framework'})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.form.hello, 'world');
-            assert.equal(result.form.beyond, 'framework');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.form.hello, 'world');
+      assert.equal(result.form.beyond, 'framework');
     });
 
-    it.will('send a put request with JSON data.', function (done) {
-      req
+    it('send a put request with JSON data.', function () {
+      var res = wait(req
         .json({'hello': 'world', 'beyond': 'framework'})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            var jsonData = JSON.parse(result.data);
-            assert.equal(jsonData.hello, 'world');
-            assert.equal(jsonData.beyond, 'framework');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      var jsonData = JSON.parse(result.data);
+      assert.equal(jsonData.hello, 'world');
+      assert.equal(jsonData.beyond, 'framework');
     });
 
-    it.will('send a put request with headers.', function (done) {
-      req
+    it('send a put request with headers.', function () {
+      var res = wait(req
         .set({'hello': 'world', 'beyond': 'framework', 'number': 1234})
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.headers.hello, 'world');
-            assert.equal(result.headers.beyond, 'framework');
-            assert.equal(result.headers.number, '1234');
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.headers.hello, 'world');
+      assert.equal(result.headers.beyond, 'framework');
+      assert.equal(result.headers.number, '1234');
     });
   });
 
   describe('#auth()', function () {
-    it.will('send a request with basic auth.', function (done) {
-      request
+    it('send a request with basic auth.', function () {
+      var res = wait(request
         .get('http://localhost:1234/basic-auth')
         .query({'id': 'hello', 'passwd': 'world'})
         .auth('hello', 'world')
-        .end()
-        .onComplete(complete(done, function (res) {
-          assert.async(done, function () {
-            var result = JSON.parse(res.body);
-            assert.equal(result.authenticated, true);
-          });
-        }));
+        .end());
+      var result = JSON.parse(res.body);
+      assert.equal(result.authenticated, true);
     });
   });
 });

--- a/plugins/test/lib/test-helper.js
+++ b/plugins/test/lib/test-helper.js
@@ -1,0 +1,2 @@
+/* global TestHelper */
+module.exports = TestHelper;


### PR DESCRIPTION
In plugin tests, there're many chances to test modules with ScriptableFuture results. Until now, we've used async tests with `it.will`, but it's been rapidly getting verbose and complicated. While adding tests for `ScriptableCollection`, I finally found that `wait` was really needed, at least for tests.

I once thought to add it as a method of `ScriptableFuture`, but I think it's better not to enable user to use `wait`, as they could use it in the production level which is a bad practice. Thus I added it as a `test-helper` module.

The first commit is to add the helper module, and the other is to modify the original tests to use the helper.