### PR TITLE
Support multiple plugins.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -97,7 +97,9 @@ beyond {
     type = "standalone"
   }
   plugin {
-    path = ["plugins"]
+    paths {
+      example = ["plugins"]
+    }
   }
   zookeeper {
     servers = ["localhost"]

--- a/core/app/beyond/BeyondConfiguration.scala
+++ b/core/app/beyond/BeyondConfiguration.scala
@@ -34,11 +34,8 @@ object BeyondConfiguration {
     configuration.getStringList("beyond.zookeeper.servers").map(_.asScala).get.toSet
   }
 
-  def pluginPaths: Seq[Path] = {
-    import scala.collection.JavaConverters._
-    val paths: Seq[String] = configuration.getStringList("beyond.plugin.path").map(_.asScala).get
-    paths.map(Path.fromString)
-  }
+  def pluginPaths: Seq[Path] =
+    configuration.getStringSeq("beyond.plugin.path").getOrElse(Seq.empty).map(Path.fromString)
 
   def encoding: String = configuration.getString("beyond.encoding").get
 

--- a/core/app/beyond/engine/javascript/BeyondJavaScriptEngine.scala
+++ b/core/app/beyond/engine/javascript/BeyondJavaScriptEngine.scala
@@ -1,6 +1,5 @@
 package beyond.engine.javascript
 
-import beyond.BeyondConfiguration
 import com.beyondframework.rhino.ScriptableMap
 import com.typesafe.scalalogging.slf4j.{ StrictLogging => Logging }
 import org.mozilla.javascript.Context
@@ -10,7 +9,7 @@ import scala.concurrent.ExecutionContext
 import scalax.file.Path
 
 class BeyondJavaScriptEngine(val global: BeyondGlobal,
-    pluginPaths: Seq[Path] = BeyondConfiguration.pluginPaths)(implicit val executionContext: ExecutionContext) extends Logging {
+    pluginPaths: Seq[Path])(implicit val executionContext: ExecutionContext) extends Logging {
   import com.beyondframework.rhino.RhinoConversions._
 
   val contextFactory: BeyondContextFactory = new BeyondContextFactory(new BeyondContextFactoryConfig, global)

--- a/core/app/beyond/plugin/GamePlugin.scala
+++ b/core/app/beyond/plugin/GamePlugin.scala
@@ -1,5 +1,6 @@
 package beyond.plugin
 
+import beyond.BeyondConfiguration
 import beyond.engine.javascript.AssetsModuleSourceProvider
 import beyond.engine.javascript.BeyondGlobal
 import beyond.engine.javascript.BeyondJavaScriptEngine
@@ -13,6 +14,7 @@ import org.mozilla.javascript.Function
 import play.api.mvc.Request
 import play.api.mvc.Result
 import scala.concurrent.Future
+import scalax.file.Path
 
 class NoHandlerFunctionFoundException extends Exception
 
@@ -20,37 +22,67 @@ object GamePlugin extends Logging {
   import com.beyondframework.rhino.RhinoConversions._
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  private val engine = {
-    val library = new AssetsModuleSourceProvider
-    new BeyondJavaScriptEngine(new BeyondGlobal(library))
-  }
+  private val library: AssetsModuleSourceProvider = new AssetsModuleSourceProvider
+
+  private val engines: Map[String, BeyondJavaScriptEngine] =
+    BeyondConfiguration.pluginPaths.map {
+      case (prefix: String, paths: Seq[Path]) =>
+        prefix -> new BeyondJavaScriptEngine(new BeyondGlobal(library), paths)
+    }
+  private lazy val defaultEngine: BeyondJavaScriptEngine =
+    new BeyondJavaScriptEngine(new BeyondGlobal(library), BeyondConfiguration.deprecatedPluginPaths)
+
   ScriptableConsole.setRedirectConsoleToLogger(true)
 
-  private val handler: Function = engine.contextFactory.call { cx: Context =>
-    val mainFilename = "main.js"
-    val exports = engine.loadMain(mainFilename)
-    // FIXME: Don't hardcode the name of handler function.
-    val handler = exports.get("handle", exports)
-    handler match {
-      case _: Function =>
-        handler
-      case _ /* Scriptable.NOT_FOUND */ =>
-        logger.error("No handler function is found")
-        throw new NoHandlerFunctionFoundException
-    }
-  }.asInstanceOf[Function]
+  private def makeHandler(engine: BeyondJavaScriptEngine): Function =
+    engine.contextFactory.call { cx: Context =>
+      val mainFilename = "main.js"
+      val exports = engine.loadMain(mainFilename)
+      // FIXME: Don't hardcode the name of handler function.
+      exports.get("handle", exports) match {
+        case handler: Function =>
+          handler
+        case _ /* Scriptable.NOT_FOUND */ =>
+          logger.error("No handler function is found")
+          throw new NoHandlerFunctionFoundException
+      }
+    }.asInstanceOf[Function]
 
-  def handle[A](request: Request[A]): Future[Result] = engine.contextFactory.call { cx: Context =>
-    val scope = engine.global
+  private val handlers: Map[String, Function] = engines.map {
+    case (prefix: String, engine: BeyondJavaScriptEngine) =>
+      prefix -> makeHandler(engine)
+  }
 
-    val args: Array[AnyRef] = Array(ScriptableRequest(cx, request))
-    val response = handler.call(cx, scope, scope, args)
-    response match {
-      case f: ScriptableFuture =>
-        f.future.mapTo[ScriptableResponse].map(_.result)
-      case res: ScriptableResponse =>
-        Future.successful(res.result)
+  private lazy val defaultHandler: Function =
+    makeHandler(defaultEngine)
+
+  private def handle[A](engine: BeyondJavaScriptEngine, handler: Function)(request: Request[A]): Future[Result] =
+    engine.contextFactory.call { cx: Context =>
+      val scope = engine.global
+      val args: Array[AnyRef] = Array(ScriptableRequest(cx, request))
+      val response = handler.call(cx, scope, scope, args)
+      response match {
+        case f: ScriptableFuture =>
+          f.future.mapTo[ScriptableResponse].map(_.result)
+        case res: ScriptableResponse =>
+          Future.successful(res.result)
+      }
+    }.asInstanceOf[Future[Result]]
+
+  def handle[A](request: Request[A]): Future[Result] = {
+    val (pluginName, pluginNameRemovedReq): (String, Request[A]) = {
+      val uris = request.uri.split("/").drop(1) // `request.uri` starts with "/".
+      val pluginName = uris(1)
+      val pluginNameRemovedUri = (uris(0) +: uris.drop(2).toSeq).mkString("/", "/", "")
+      pluginName -> Request(request.copy(uri = pluginNameRemovedUri), request.body)
     }
-  }.asInstanceOf[Future[Result]]
+
+    engines.get(pluginName) match {
+      case None =>
+        handle(defaultEngine, defaultHandler)(request)
+      case Some(engine: BeyondJavaScriptEngine) =>
+        handle(engine, handlers(pluginName))(pluginNameRemovedReq)
+    }
+  }
 }
 


### PR DESCRIPTION
Currently, beyond supports only one javascript plugin. This patch makes
beyond support multiple plugins.

This patch adds beyond.plugin.paths option, this option is consists of
plugin names and paths. For example if beyond.plugin.paths is looks
like below

beyond.plugin.paths = {
  logicServer = [ "/path/to/logic/server" ]
  admin = [ "/path/to/admin/server" ]
}

the request to "//plugin/logicServer/*" URI will use "/path/to/logic/server"
plugin with "/plugin/*" request URI, and the URI to "//plugin/admin/*"
will use "/path/to/admin/server" plugin with "/plugin/*" request URI.
In other words, the Request passed to plugin will remove plugin name
from the URI.

The beyond.plugin.path option remains. It will be used as the default
plugin path. If there is no matching name with URI in paths, the
default plugin will be used.