### PR TITLE
Separate MongoConfiguration from BeyondConfiguration.

### DIFF
--- a/core/app/beyond/config/BeyondConfiguration.scala
+++ b/core/app/beyond/config/BeyondConfiguration.scala
@@ -11,8 +11,6 @@ import scalax.file.Path
 object BeyondConfiguration extends Logging {
   implicit private val configurationPrefix: String = "beyond"
 
-  lazy val mongo = MongoConfiguration
-
   def requestTimeout: FiniteDuration =
     Duration(configuration.getString("request-timeout").get).asInstanceOf[FiniteDuration]
 

--- a/core/app/beyond/launcher/LauncherSupervisor.scala
+++ b/core/app/beyond/launcher/LauncherSupervisor.scala
@@ -6,6 +6,7 @@ import akka.actor.OneForOneStrategy
 import akka.actor.Props
 import akka.actor.SupervisorStrategy._
 import beyond.config.BeyondConfiguration
+import beyond.config.MongoConfiguration
 import beyond.launcher.mongodb.MongoDBConfigLauncher
 import beyond.launcher.mongodb.MongoDBInstanceType
 import beyond.launcher.mongodb.MongoDBStandaloneLauncher
@@ -40,7 +41,7 @@ class LauncherSupervisor extends Actor with ActorLogging {
   }
 
   private def launchMongoDBServerIfNecessary() {
-    BeyondConfiguration.mongo.instanceType match {
+    MongoConfiguration.instanceType match {
       case MongoDBInstanceType.Standalone =>
         context.actorOf(Props[MongoDBStandaloneLauncher], name = "mongoDBStandaloneLauncher")
       case MongoDBInstanceType.Config =>

--- a/core/app/beyond/launcher/mongodb/MongoDBConfigServerLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBConfigServerLauncher.scala
@@ -1,6 +1,6 @@
 package beyond.launcher.mongodb
 
-import beyond.config.BeyondConfiguration
+import beyond.config.MongoConfiguration
 import java.io.File
 import scala.sys.process._
 
@@ -12,12 +12,12 @@ class MongoDBConfigLauncher extends MongoDBLauncher {
   override protected val shouldCheckHealth: Boolean = false
 
   override protected def launchProcess() {
-    val dbPath = new File(BeyondConfiguration.mongo.configDbPath)
+    val dbPath = new File(MongoConfiguration.configDbPath)
     if (!dbPath.exists()) {
       dbPath.mkdirs()
     }
 
-    val port = BeyondConfiguration.mongo.configPort
+    val port = MongoConfiguration.configPort
 
     val path: String = mongodPath.getOrElse {
       throw new LauncherInitializationException

--- a/core/app/beyond/launcher/mongodb/MongoDBStandaloneLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBStandaloneLauncher.scala
@@ -1,6 +1,6 @@
 package beyond.launcher.mongodb
 
-import beyond.config.BeyondConfiguration
+import beyond.config.MongoConfiguration
 import java.io.File
 import scala.sys.process._
 
@@ -11,7 +11,7 @@ class MongoDBStandaloneLauncher extends MongoDBLauncher {
   override protected val pidFileName: String = "mongo-standalone.pid"
 
   override protected def launchProcess() {
-    val dbPath = new File(BeyondConfiguration.mongo.dbPath)
+    val dbPath = new File(MongoConfiguration.dbPath)
     if (!dbPath.exists()) {
       dbPath.mkdirs()
     }


### PR DESCRIPTION
It is not needed to keep a `mongo` property in BeyondConfiguration.

It may conflict with #196, so I'll update this PR with the conflict resolved and the new `ConfigurationMixin` applied after the PR is merged.