### PR TITLE
Make configuration function instead of ConfigurationMixin.

### DIFF
--- a/core/app/beyond/Authenticated.scala
+++ b/core/app/beyond/Authenticated.scala
@@ -1,5 +1,6 @@
 package beyond
 
+import beyond.config.BeyondConfiguration
 import beyond.route.RouteAddress
 import beyond.route.RoutingTableView
 import beyond.route.RoutingTableView.HandleHere

--- a/core/app/beyond/BeyondMBean.scala
+++ b/core/app/beyond/BeyondMBean.scala
@@ -1,5 +1,6 @@
 package beyond
 
+import beyond.config.BeyondConfiguration
 import beyond.metrics.NumberOfRequestsPerSecond
 import java.lang.management.ManagementFactory
 import javax.management.MBeanServer

--- a/core/app/beyond/BeyondSupervisor.scala
+++ b/core/app/beyond/BeyondSupervisor.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorPath
 import akka.actor.Address
 import akka.actor.Props
 import akka.actor.RootActorPath
+import beyond.config.BeyondConfiguration
 import beyond.launcher.LauncherSupervisor
 import beyond.metrics.SystemMetricsSupervisor
 

--- a/core/app/beyond/CuratorSupervisor.scala
+++ b/core/app/beyond/CuratorSupervisor.scala
@@ -3,6 +3,7 @@ package beyond
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.Props
+import beyond.config.BeyondConfiguration
 import beyond.route.RoutingTableUpdater
 import beyond.route.RoutingTableWatcher
 import com.typesafe.scalalogging.slf4j.{ StrictLogging => Logging }

--- a/core/app/beyond/TimeoutFilter.scala
+++ b/core/app/beyond/TimeoutFilter.scala
@@ -1,5 +1,6 @@
 package beyond
 
+import beyond.config.BeyondConfiguration
 import play.api.libs.concurrent.Promise
 import play.api.mvc._
 import play.api.mvc.Results.InternalServerError

--- a/core/app/beyond/WorkerRegistrationActor.scala
+++ b/core/app/beyond/WorkerRegistrationActor.scala
@@ -2,6 +2,7 @@ package beyond
 
 import akka.actor.Actor
 import akka.actor.ActorLogging
+import beyond.config.BeyondConfiguration
 import java.nio.charset.Charset
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode
@@ -16,7 +17,7 @@ class WorkerRegistrationActor(curatorFramework: CuratorFramework) extends Actor 
 
   private val workerNode = new PersistentEphemeralNode(
     curatorFramework, PersistentEphemeralNode.Mode.PROTECTED_EPHEMERAL_SEQUENTIAL, WorkersPath + "/w-",
-    beyond.BeyondConfiguration.currentServerRouteAddress.getBytes(Charset.forName("UTF-8")))
+    BeyondConfiguration.currentServerRouteAddress.getBytes(Charset.forName("UTF-8")))
 
   override def preStart() {
     curatorFramework.create().inBackground().forPath(WorkersPath, Array[Byte](0))

--- a/core/app/beyond/config/BeyondConfiguration.scala
+++ b/core/app/beyond/config/BeyondConfiguration.scala
@@ -8,19 +8,21 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scalax.file.Path
 
-object BeyondConfiguration extends Logging with ConfigurationMixin {
+object BeyondConfiguration extends Logging {
+  implicit private val configurationPrefix: String = "beyond"
+
   lazy val mongo = MongoConfiguration
 
   def requestTimeout: FiniteDuration =
-    Duration(configuration.getString("beyond.request-timeout").get).asInstanceOf[FiniteDuration]
+    Duration(configuration.getString("request-timeout").get).asInstanceOf[FiniteDuration]
 
-  def zooKeeperConfigPath: String = configuration.getString("beyond.zookeeper.config-path").get
+  def zooKeeperConfigPath: String = configuration.getString("zookeeper.config-path").get
 
-  def pidDirectory: String = configuration.getString("beyond.pid-dir").get
+  def pidDirectory: String = configuration.getString("pid-dir").get
 
   def zooKeeperServers: Set[String] = {
     import scala.collection.JavaConverters._
-    configuration.getStringList("beyond.zookeeper.servers").map(_.asScala).get.toSet
+    configuration.getStringList("zookeeper.servers").map(_.asScala).get.toSet
   }
 
   private val DeprecatedPluginPathsMessage =
@@ -28,38 +30,38 @@ object BeyondConfiguration extends Logging with ConfigurationMixin {
   @deprecated(message = DeprecatedPluginPathsMessage)
   def deprecatedPluginPaths: Seq[Path] = {
     logger.warn(DeprecatedPluginPathsMessage)
-    configuration.getStringSeq("beyond.plugin.path").getOrElse(Seq.empty).map(Path.fromString)
+    configuration.getStringSeq("plugin.path").getOrElse(Seq.empty).map(Path.fromString)
   }
 
   def pluginPaths: Map[String, Seq[Path]] =
-    configuration.getConfig("beyond.plugin.paths").map { config =>
+    configuration.getConfig("plugin.paths").map { config =>
       config.keys.toSeq.map { pluginName =>
         pluginName -> config.getStringSeq(pluginName).get.map(Path.fromString)
       }.toMap[String, Seq[Path]]
     } getOrElse Map.empty
 
-  def encoding: String = configuration.getString("beyond.encoding").get
+  def encoding: String = configuration.getString("encoding").get
 
   def curatorConnectionPolicy: RetryPolicy = {
-    val curatorPath = "beyond.curator.connection"
+    val curatorPath = "curator.connection"
     val baseSleepTimeMs = Duration(configuration.getString(s"$curatorPath.base-sleep-time").get).toMillis.toInt
     val maxRetries = configuration.getInt(s"$curatorPath.max-retries").get
     val maxSleepMs = Duration(configuration.getString(s"$curatorPath.max-sleep").get).toMillis.toInt
     new ExponentialBackoffRetry(baseSleepTimeMs, maxRetries, maxSleepMs)
   }
 
-  def currentServerAddress: String = configuration.getString("http.address").get
+  def currentServerAddress: String = rootConfiguration.getString("http.address").get
 
   def currentServerRouteAddress: RouteAddress = {
-    val hostAddress = configuration.getString("http.address").get
-    val port = configuration.getInt("http.port").get
+    val hostAddress = rootConfiguration.getString("http.address").get
+    val port = rootConfiguration.getInt("http.port").get
 
     RouteAddress(hostAddress, port.toString)
   }
 
   def isStandaloneMode: Boolean =
-    configuration.getBoolean("beyond.standalone-mode").getOrElse(false)
+    configuration.getBoolean("standalone-mode").getOrElse(false)
 
   def enableMetrics: Boolean =
-    configuration.getBoolean("beyond.enable-metrics").getOrElse(true)
+    configuration.getBoolean("enable-metrics").getOrElse(true)
 }

--- a/core/app/beyond/config/BeyondConfiguration.scala
+++ b/core/app/beyond/config/BeyondConfiguration.scala
@@ -1,4 +1,4 @@
-package beyond
+package beyond.config
 
 import beyond.route.RouteAddress
 import com.typesafe.scalalogging.slf4j.{ StrictLogging => Logging }

--- a/core/app/beyond/config/ConfigurationMixin.scala
+++ b/core/app/beyond/config/ConfigurationMixin.scala
@@ -1,4 +1,4 @@
-package beyond
+package beyond.config
 
 import java.io.File
 import play.api.Configuration

--- a/core/app/beyond/config/MongoConfiguration.scala
+++ b/core/app/beyond/config/MongoConfiguration.scala
@@ -2,9 +2,11 @@ package beyond.config
 
 import beyond.launcher.mongodb.MongoDBInstanceType
 
-object MongoConfiguration extends ConfigurationMixin {
+object MongoConfiguration {
+  implicit private val configurationPrefix: String = "beyond.mongodb"
+
   lazy val instanceType: MongoDBInstanceType.Value =
-    configuration.getString("beyond.mongodb.type")
+    configuration.getString("type")
       .map {
         case "standalone" => MongoDBInstanceType.Standalone
         case "config" => MongoDBInstanceType.Config
@@ -14,11 +16,11 @@ object MongoConfiguration extends ConfigurationMixin {
       }
       .getOrElse(MongoDBInstanceType.default)
 
-  lazy val dbPath: String = configuration.getString("beyond.mongodb.dbpath").get
+  lazy val dbPath: String = configuration.getString("dbpath").get
 
   lazy val configDbPath: String =
-    configuration.getString("beyond.mongodb.config.dbpath").get
+    configuration.getString("config.dbpath").get
 
   lazy val configPort: String =
-    configuration.getString("beyond.mongodb.config.port").get
+    configuration.getString("config.port").get
 }

--- a/core/app/beyond/config/MongoConfiguration.scala
+++ b/core/app/beyond/config/MongoConfiguration.scala
@@ -1,4 +1,4 @@
-package beyond
+package beyond.config
 
 import beyond.launcher.mongodb.MongoDBInstanceType
 

--- a/core/app/beyond/config/package.scala
+++ b/core/app/beyond/config/package.scala
@@ -1,10 +1,10 @@
-package beyond.config
+package beyond
 
 import java.io.File
 import play.api.Configuration
 
-trait ConfigurationMixin {
-  protected def configuration =
+package object config {
+  private[config] def rootConfiguration =
     try {
       play.api.Play.current.configuration
     } catch {
@@ -12,4 +12,7 @@ trait ConfigurationMixin {
       // Mainly for tests or console
       case _: RuntimeException => Configuration.load(new File("."))
     }
+
+  private[config] def configuration(implicit prefix: String) =
+    rootConfiguration.getConfig(prefix).getOrElse(Configuration.empty)
 }

--- a/core/app/beyond/engine/javascript/lib/ScriptableBuffer.scala
+++ b/core/app/beyond/engine/javascript/lib/ScriptableBuffer.scala
@@ -1,6 +1,6 @@
 package beyond.engine.javascript.lib
 
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import beyond.engine.javascript.BeyondContextFactory
 import beyond.engine.javascript.JSArray
 import beyond.engine.javascript.JSFunction

--- a/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFileSystem.scala
+++ b/core/app/beyond/engine/javascript/lib/filesystem/ScriptableFileSystem.scala
@@ -1,6 +1,6 @@
 package beyond.engine.javascript.lib.filesystem
 
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import beyond.engine.javascript.BeyondContext
 import beyond.engine.javascript.BeyondContextFactory
 import beyond.engine.javascript.JSArray

--- a/core/app/beyond/launcher/LauncherSupervisor.scala
+++ b/core/app/beyond/launcher/LauncherSupervisor.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorLogging
 import akka.actor.OneForOneStrategy
 import akka.actor.Props
 import akka.actor.SupervisorStrategy._
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import beyond.launcher.mongodb.MongoDBConfigLauncher
 import beyond.launcher.mongodb.MongoDBInstanceType
 import beyond.launcher.mongodb.MongoDBStandaloneLauncher

--- a/core/app/beyond/launcher/ZooKeeperLauncher.scala
+++ b/core/app/beyond/launcher/ZooKeeperLauncher.scala
@@ -7,9 +7,9 @@ import akka.actor.Cancellable
 import akka.io.IO
 import akka.io.Tcp
 import akka.util.ByteString
-import beyond.BeyondConfiguration
 import beyond.BeyondRuntime
 import beyond.TickGenerator
+import beyond.config.BeyondConfiguration
 import java.net.InetSocketAddress
 import org.apache.zookeeper.server.ServerConfig
 import scala.concurrent.duration._

--- a/core/app/beyond/launcher/mongodb/MongoDBConfigServerLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBConfigServerLauncher.scala
@@ -1,6 +1,6 @@
 package beyond.launcher.mongodb
 
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import java.io.File
 import scala.sys.process._
 

--- a/core/app/beyond/launcher/mongodb/MongoDBLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBLauncher.scala
@@ -2,9 +2,9 @@ package beyond.launcher.mongodb
 
 import akka.actor.Actor
 import akka.actor.ActorLogging
-import beyond.BeyondConfiguration
 import beyond.MongoMixin
 import beyond.TickGenerator
+import beyond.config.BeyondConfiguration
 import java.io.IOException
 import play.api.libs.concurrent.Akka
 import reactivemongo.core.commands.Status

--- a/core/app/beyond/launcher/mongodb/MongoDBStandaloneLauncher.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBStandaloneLauncher.scala
@@ -1,6 +1,6 @@
 package beyond.launcher.mongodb
 
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import java.io.File
 import scala.sys.process._
 

--- a/core/app/beyond/metrics/RequestsCountFilter.scala
+++ b/core/app/beyond/metrics/RequestsCountFilter.scala
@@ -1,7 +1,7 @@
 package beyond.metrics
 
 import akka.actor.Props
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import play.api.libs.concurrent.Akka
 import play.api.mvc._
 import scala.concurrent.Future

--- a/core/app/beyond/metrics/SystemMetricsSupervisor.scala
+++ b/core/app/beyond/metrics/SystemMetricsSupervisor.scala
@@ -6,8 +6,8 @@ import akka.actor.Props
 import akka.pattern.ask
 import akka.pattern.pipe
 import akka.util.Timeout
-import beyond.BeyondConfiguration
 import beyond.TickGenerator
+import beyond.config.BeyondConfiguration
 import java.util.Date
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/core/app/beyond/plugin/GamePlugin.scala
+++ b/core/app/beyond/plugin/GamePlugin.scala
@@ -1,6 +1,6 @@
 package beyond.plugin
 
-import beyond.BeyondConfiguration
+import beyond.config.BeyondConfiguration
 import beyond.engine.javascript.AssetsModuleSourceProvider
 import beyond.engine.javascript.BeyondGlobal
 import beyond.engine.javascript.BeyondJavaScriptEngine


### PR DESCRIPTION
This patch removes ConfigurationMixin with configuration function.
It works same as ConfigurationMixin except there is no needs to inherit something to use configration function in the config package because Configuration function is package private.

And make configuration need implicit parameter as the prefix. You have to use rootConfiguration function to get configuration without prefix.