### PR TITLE
Ignore scalastyle null checker explicitly when passing null to Rhino.

### DIFF
--- a/core/app/beyond/engine/javascript/AssetsModuleSourceProvider.scala
+++ b/core/app/beyond/engine/javascript/AssetsModuleSourceProvider.scala
@@ -16,7 +16,7 @@ class AssetsModuleSourceProvider extends ModuleSourceProvider with StrictLogging
       resource =>
         val stream = resource.openStream()
         val source = Source.fromInputStream(stream).getLines().mkString("\n")
-        new ModuleSource(new StringReader(source), null, resource.toURI, resource.toURI, validator)
+        new ModuleSource(new StringReader(source), null, resource.toURI, resource.toURI, validator) // scalastyle:ignore null
     }.orNull
   }
 

--- a/core/app/beyond/engine/javascript/BeyondGlobal.scala
+++ b/core/app/beyond/engine/javascript/BeyondGlobal.scala
@@ -152,7 +152,7 @@ class BeyondGlobal(libraryProvider: ModuleSourceProvider) extends ImporterTopLev
     }
 
     val providers = Seq(
-      new SoftCachingModuleScriptProvider(new UrlModuleSourceProvider(uris.asJava, null)),
+      new SoftCachingModuleScriptProvider(new UrlModuleSourceProvider(uris.asJava, null)), // scalastyle:ignore null
       new StrongCachingModuleScriptProvider(libraryProvider)
     )
 

--- a/core/app/beyond/engine/javascript/lib/ScriptableBuffer.scala
+++ b/core/app/beyond/engine/javascript/lib/ScriptableBuffer.scala
@@ -183,7 +183,7 @@ class ScriptableBuffer(val internal: ByteBuffer) extends ScriptableObject {
     try {
       new Integer(internal.get(index) & 0xFF)
     } catch {
-      case _: IndexOutOfBoundsException => null
+      case _: IndexOutOfBoundsException => null // scalastyle:ignore null
     }
   }
 

--- a/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
@@ -88,7 +88,7 @@ object ScriptableCollection {
 
     val convertedToScriptableDocumentResult = findResult.map {
       case None =>
-        null
+        null // scalastyle:ignore null
       case Some(document) =>
         convertDocumentToJsObject(context, thisCollection, document)
     }
@@ -114,7 +114,7 @@ object ScriptableCollection {
 
     val convertedToScriptableDocumentResult = findResult.map {
       case None =>
-        null
+        null // scalastyle:ignore null
       case Some(document) =>
         convertDocumentToJsObject(context, thisCollection, document)
     }

--- a/core/app/beyond/engine/javascript/lib/database/package.scala
+++ b/core/app/beyond/engine/javascript/lib/database/package.scala
@@ -48,7 +48,7 @@ package object database extends Logging {
         id
       case native: NativeJavaObject =>
         write(native.unwrap())
-      case null =>
+      case null => // scalastyle:ignore null
         BSONNull
       case _ =>
         throw new IllegalArgumentException(s"$value(${value.getClass} cannot be a BSONValue")
@@ -71,7 +71,7 @@ package object database extends Logging {
         array.values.map(read)
       case id: BSONObjectID => ObjectId(id)
       case BSONNull =>
-        null
+        null // scalastyle:ignore null
       case _ =>
         throw new IllegalArgumentException(s"$bson cannot be a scala object")
     }
@@ -185,18 +185,18 @@ package object database extends Logging {
       context.newObject(scope, "Array", args)
     case objectID: ObjectId =>
       context.newObject(scope, "ObjectId", objectID.toString)
-    case null =>
-      null
+    case null => // scalastyle:ignore null
+      null // scalastyle:ignore null
     case _ =>
       throw new IllegalArgumentException(s"$value(${value.getClass} cannot be a JavaScript Object")
   }
 
   private[database] def convertJavaScriptToScalaWithField(value: AnyRef)(implicit field: Field): AnyRef = (value, field) match {
-    case (null, field: Field) if field.defaultValue.isDefined =>
-      null
-    case (null, field: Field) if field.isNullable =>
-      null
-    case (null, field: Field) =>
+    case (null, field: Field) if field.defaultValue.isDefined => // scalastyle:ignore null
+      null // scalastyle:ignore null
+    case (null, field: Field) if field.isNullable => // scalastyle:ignore null
+      null // scalastyle:ignore null
+    case (null, field: Field) => // scalastyle:ignore null
       throw new IllegalArgumentException(s"$field is not optional field.")
     case (native: NativeJavaObject, field: Field) =>
       convertJavaScriptToScalaWithField(native.unwrap())(field)

--- a/core/app/beyond/engine/javascript/lib/http/ScriptableResponse.scala
+++ b/core/app/beyond/engine/javascript/lib/http/ScriptableResponse.scala
@@ -39,7 +39,7 @@ object ScriptableResponse {
       case other =>
         val beyondContextFactory = context.getFactory.asInstanceOf[BeyondContextFactory]
         val scope = beyondContextFactory.global
-        NativeJSON.stringify(context, scope, other, null, null).asInstanceOf[String]
+        NativeJSON.stringify(context, scope, other, null, null).asInstanceOf[String] // scalastyle:ignore null
     }
 
   def jsConstructor(context: Context, args: JSArray, constructor: JSFunction, inNewExpr: Boolean): ScriptableResponse = {

--- a/core/app/beyond/plugin/test/TestRunner.scala
+++ b/core/app/beyond/plugin/test/TestRunner.scala
@@ -38,7 +38,7 @@ object TestRunner extends App {
           uri.toString.endsWith("/") ? uri | new URI(uri + "/")
         }
     import scala.collection.JavaConversions.asJavaIterable
-    new UrlModuleSourceProvider(libraryPath, null)
+    new UrlModuleSourceProvider(libraryPath, null) // scalastyle:ignore null
   }
 
   private val scope = new BeyondTestGlobal(library)
@@ -64,8 +64,8 @@ object TestRunner extends App {
         TestReporter.fileStart(currentFile.getName)
 
         val scriptScope = cx.initStandardObjects(scope)
-        cx.compileReader(new FileReader(currentFile), currentFile.getName, 0, null).exec(cx, scriptScope)
-        cx.compileString("run()", currentFile.getName, 0, null).exec(cx, scriptScope)
+        cx.compileReader(new FileReader(currentFile), currentFile.getName, 0, null).exec(cx, scriptScope) // scalastyle:ignore null
+        cx.compileString("run()", currentFile.getName, 0, null).exec(cx, scriptScope) // scalastyle:ignore null
       } catch {
         case e: EcmaError =>
           TestReporter.fileRuntimeError(currentFile.getName, e.getErrorMessage, e.getScriptStackTrace)

--- a/core/app/beyond/tool/BeyondShellGlobal.scala
+++ b/core/app/beyond/tool/BeyondShellGlobal.scala
@@ -16,7 +16,7 @@ import scala.io.Source
 object BeyondShellGlobal {
   private def loadFile(cx: Context, scope: Scriptable, path: String) {
     val src = Source.fromFile(path)(Codec.UTF8).getLines().mkString("\n")
-    val script = cx.compileString(src, path, 1, null)
+    val script = cx.compileString(src, path, 1, null) // scalastyle:ignore null
     script.exec(cx, scope)
   }
 

--- a/core/app/beyond/tool/JavaScriptShellConsole.scala
+++ b/core/app/beyond/tool/JavaScriptShellConsole.scala
@@ -103,7 +103,7 @@ object JavaScriptShellConsole extends App {
           uri.toString.endsWith("/") ? uri | new URI(uri + "/")
         }
     import scala.collection.JavaConversions.asJavaIterable
-    new UrlModuleSourceProvider(libraryPath, null)
+    new UrlModuleSourceProvider(libraryPath, null) // scalastyle:ignore null
   }
   val scope = new BeyondShellGlobal(library)
 
@@ -153,7 +153,7 @@ object JavaScriptShellConsole extends App {
   }
 
   def compileSource(cx: Context, source: Source): Script = {
-    cx.compileString(source.text, "<stdin>", source.lineNumber, null)
+    cx.compileString(source.text, "<stdin>", source.lineNumber, null) // scalastyle:ignore null
   }
 
   def evaluateScript(cx: Context, script: Script): AnyRef = {


### PR DESCRIPTION
No way to avoid using null for these cases, because Rhino is Java library and
they needs null as an argument.

This is a part of #202