### PR TITLE
Add `drop` method to ScriptableCollection.

### DIFF
--- a/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
+++ b/core/app/beyond/engine/javascript/lib/database/ScriptableCollection.scala
@@ -155,6 +155,14 @@ object ScriptableCollection {
     ScriptableFuture(context, scriptableDocument)
   }
 
+  @JSFunctionAnnotation
+  def drop(context: Context, thisObj: Scriptable, args: JSArray, function: JSFunction): ScriptableFuture = {
+    implicit val executionContext = context.asInstanceOf[BeyondContext].executionContext
+    val thisCollection = thisObj.asInstanceOf[ScriptableCollection]
+    val dropResult = thisCollection.dropInternal()
+    ScriptableFuture(context, dropResult)
+  }
+
   def jsConstructor(context: Context, args: JSArray, constructor: JSFunction, inNewExpr: Boolean): ScriptableCollection = {
     val name = args(0).asInstanceOf[String]
     val schema = args(1).asInstanceOf[ScriptableSchema]
@@ -258,4 +266,8 @@ class ScriptableCollection(name: String, schema: ScriptableSchema) extends Scrip
       case _ =>
         true
     }
+
+  // Cannot use name 'drop', because static forwarder is not generated when the companion object and class have the same name method.
+  private def dropInternal()(implicit ec: ExecutionContext): Future[Boolean] =
+    collection.drop().recover { case _ => false }
 }

--- a/plugins/examples/db.js
+++ b/plugins/examples/db.js
@@ -94,6 +94,10 @@ exports.removeOne = function () {
   return collection.removeOne(q).onSuccess(console.info).onFailure(console.error);
 };
 
+exports.drop = function () {
+  return collection.drop().onSuccess(console.info).onFailure(console.error);
+};
+
 exports.save = function () {
   var queries = Array.prototype.slice.call(arguments, 1).map(function (arg) {
     return db.query("key", arg);

--- a/plugins/main.js
+++ b/plugins/main.js
@@ -105,6 +105,9 @@ exports.handle = function (req) {
     case "removeOne":
       db.removeOne.apply(db.remove, tokens);
       break;
+    case "drop":
+      f = db.drop();
+      return f.map(function (v) { return new Response(v); });
     case "findOneWithKey":
       db.findOneWithKey(tokens[0]);
       break;

--- a/plugins/test/db.js
+++ b/plugins/test/db.js
@@ -302,4 +302,24 @@ describe('Collection', function () {
       assert.equal(result.value(), 55);
     });
   });
+
+  describe('#drop()', function () {
+    beforeEach(function () {
+      wait(c.insert({key: 'key1', value: 10, time: new Date()}));
+      wait(c.insert({key: 'key2', value: 20, time: new Date()}));
+      wait(c.insert({key: 'key3', value: 30, time: new Date()}));
+    });
+
+    it('drops a collection successfully.', function () {
+      var dropResult = wait(c.drop({}));
+      assert.equal(dropResult, true);
+
+      var findResult = wait(c.find(db.query().where(function () { return true; })));
+      assert.equal(findResult.length, 0);
+      assert.equal(findResult[0], undefined);
+
+      var secondDropResult = wait(c.drop());
+      assert.equal(secondDropResult, false);
+    });
+  });
 });

--- a/plugins/test/db.js
+++ b/plugins/test/db.js
@@ -158,7 +158,7 @@ describe('Collection', function () {
 
   describe('#insert()', function () {
     afterEach(function () {
-      wait(c.remove(db.query().where(function () { return true; })));
+      wait(c.drop());
     });
 
     it('inserts an object into a collection', function () {
@@ -193,7 +193,7 @@ describe('Collection', function () {
     });
 
     afterEach(function () {
-      wait(c.remove(db.query().where(function () { return true; })));
+      wait(c.drop());
     });
 
     it('finds entities meeting a query condition.', function () {
@@ -218,7 +218,7 @@ describe('Collection', function () {
     });
 
     afterEach(function () {
-      wait(c.remove(db.query().where(function () { return true; })));
+      wait(c.drop());
     });
 
     it('finds a single entity meeting a query condition.', function () {
@@ -239,7 +239,7 @@ describe('Collection', function () {
     });
 
     afterEach(function () {
-      wait(c.remove(db.query().where(function () { return true; })));
+      wait(c.drop());
     });
 
     it('removes entities meeting a query condition.', function () {
@@ -263,7 +263,7 @@ describe('Collection', function () {
     });
 
     afterEach(function () {
-      wait(c.remove(db.query().where(function () { return true; })));
+      wait(c.drop());
     });
 
     it('removes a single entity meeting a query condition.', function () {
@@ -285,7 +285,7 @@ describe('Collection', function () {
     });
 
     afterEach(function () {
-      wait(c.remove(db.query().where(function () { return true; })));
+      wait(c.drop());
     });
 
     it('updates a document.', function () {


### PR DESCRIPTION
Not Reviewed.

A `drop` method drops a collection and returns boolean future.

Returns:
  true - when successfully drops a collection.
  false - when collection to drop does not exist.
