### PR TITLE
Add a option to non-mongodb mode.

### DIFF
--- a/core/app/beyond/config/MongoConfiguration.scala
+++ b/core/app/beyond/config/MongoConfiguration.scala
@@ -12,6 +12,7 @@ object MongoConfiguration {
         case "config" => MongoDBInstanceType.Config
         case "routing" => MongoDBInstanceType.Routing
         case "shard" => MongoDBInstanceType.Shard
+        case "none" => MongoDBInstanceType.None
         case _ => throw new IllegalArgumentException("wrong.mongodb.type")
       }
       .getOrElse(MongoDBInstanceType.default)

--- a/core/app/beyond/launcher/LauncherSupervisor.scala
+++ b/core/app/beyond/launcher/LauncherSupervisor.scala
@@ -34,6 +34,7 @@ class LauncherSupervisor extends Actor {
         context.actorOf(Props[MongoDBStandaloneLauncher], name = "mongoDBStandaloneLauncher")
       case MongoDBInstanceType.Config =>
         context.actorOf(Props[MongoDBConfigLauncher], name = "mongoDBConfigLauncher")
+      case MongoDBInstanceType.None =>
       case _ =>
         // FIXME: launch a proper MongoDB instance for sharding.
         ???

--- a/core/app/beyond/launcher/mongodb/MongoDBInstanceType.scala
+++ b/core/app/beyond/launcher/mongodb/MongoDBInstanceType.scala
@@ -1,6 +1,6 @@
 package beyond.launcher.mongodb
 
 object MongoDBInstanceType extends Enumeration {
-  val Standalone, Config, Routing, Shard = Value
+  val Standalone, Config, Routing, Shard, None = Value
   val default = Standalone
 }


### PR DESCRIPTION
Currently, there is no way to use external mongo db.
This patch makes do not launch mongo db server if beyond.mongodb.type is "none".
